### PR TITLE
20260427 #5 v1 x 사진 썸네일 매핑 mapped thumb phase d 큐레이션 시각 iterate

### DIFF
--- a/assets/icons/icon_play.svg
+++ b/assets/icons/icon_play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <path d="M5 3.5 L5 12.5 L12 8 Z" fill="currentColor"/>
+</svg>

--- a/docs/superpowers/plans/2026-04-27-mapped-thumb.md
+++ b/docs/superpowers/plans/2026-04-27-mapped-thumb.md
@@ -1,0 +1,1252 @@
+# Suggestion 사진 썸네일 매핑 (`_MappedThumb`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Suggestion 카드의 셀 빌더를 `_PlaceholderCell` 에서 `_MappedThumb` 로 교체해 `GridSuggestion.mediaByCellId` 를 실제 사진/영상 첫 프레임 썸네일로 시각화.
+
+**Architecture:** `selectedAssetsProvider` (keepAlive) 가 picker 라우트 떠난 후에도 `Map<String, AssetEntity>` 보존. `_MappedThumb` (ConsumerStatefulWidget) 가 cellId → assetId → AssetEntity 해석 후 `ThumbnailLoader` 어댑터로 비동기 byte 로드 → `Image.memory(fit: cover)` + 영상 ▶ overlay. PageView 에 `allowImplicitScrolling: true` 추가해 인접 1장 preload.
+
+**Tech Stack:** Flutter 3.9.2, Riverpod (`flutter_riverpod` + `riverpod_annotation`), Freezed, photo_manager 3.9, photo_manager_image_provider 2.1, flutter_svg, flutter_screenutil, go_router.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-mapped-thumb-design.md`
+**Issue:** GitHub #5 — `.issues/20260427_기능추가_Suggestion_사진_썸네일_매핑.md`
+**Branch:** `20260427_#5_v1_x_사진_썸네일_매핑_MappedThumb_Phase_D_큐레이션_시각_iterate` (브랜치 이름에 "Phase D" 포함되지만 본 PR 범위에서 분리 — spec §11 / plan Out of Scope)
+
+---
+
+## File Map
+
+### 신규
+| 파일 | 책임 |
+|---|---|
+| `lib/features/suggestion/providers/selected_assets_provider.dart` (+ `.g.dart`) | `Map<String, AssetEntity>` 보존 (keepAlive) |
+| `lib/features/suggestion/providers/thumbnail_loader.dart` (+ `.g.dart`) | photo_manager `thumbnailDataWithSize` 1점 격리 (인터페이스 + 프로덕션 구현 + Riverpod provider) |
+| `assets/icons/icon_play.svg` | 영상 셀 우상단 ▶ 인디케이터 자산 |
+| `test/features/suggestion/providers/selected_assets_provider_test.dart` | provider 단위 |
+| `test/features/suggestion/widgets/mapped_thumb_test.dart` | `_MappedThumb` 분기 6 케이스 |
+
+### 수정
+| 파일 | 변경 |
+|---|---|
+| `lib/features/suggestion/widgets/suggestion_card.dart` | `assetsById` prop 추가, `cellBuilder` 를 `_MappedThumb` 로 교체. `_PlaceholderCell` 은 fallback 용 private 유지. `_MappedThumb` 는 inline private |
+| `lib/features/suggestion/suggestion_page.dart` | `selectedAssetsProvider` watch + `SuggestionCard` 에 `assetsById` prop. `PageView.builder(allowImplicitScrolling: true, ...)` 한 줄 추가 |
+| `lib/features/photo_picker/photo_picker_page.dart` | `_onNext` 에서 `setMedia` 와 페어로 `setAssets` 호출 |
+| `pubspec.yaml` | `assets/icons/icon_play.svg` 등록 (디렉터리 등록만 돼있는지 먼저 확인) |
+| `test/features/suggestion/suggestion_card_test.dart` | placeholder 가정 → mapped 가정으로 갱신 |
+| `test/features/photo_picker/photo_picker_page_test.dart` | `_onNext` 후 selectedAssetsProvider 채워짐 검증 케이스 추가 |
+| `docs/superpowers/specs/2026-04-27-suggestion-flow-design.md` | §"GridTemplatePreview 승격" 표 v1.x 행 = 완료 ✓ + 본 spec cross-link |
+
+### 본 plan 의 build_runner 가정
+프로젝트 컨벤션: `dart run build_runner watch --delete-conflicting-outputs` 가 background 로 돌고 있음. Riverpod / Freezed 코드 생성이 즉시 반영. 만약 watch 가 안 돌면 각 Task 끝에 `dart run build_runner build --delete-conflicting-outputs` 한 번 실행 후 진행.
+
+---
+
+## Task 1: `SelectedAssetsNotifier` provider
+
+**Files:**
+- Create: `lib/features/suggestion/providers/selected_assets_provider.dart`
+- Create: `test/features/suggestion/providers/selected_assets_provider_test.dart`
+
+- [ ] **Step 1.1: Write failing test**
+
+`test/features/suggestion/providers/selected_assets_provider_test.dart`:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gridset/features/suggestion/providers/selected_assets_provider.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+// 테스트용 가짜 AssetEntity — id 만 사용. photo_manager 의 AssetEntity 는
+// final 클래스라 `AssetEntity(id: ..., typeInt: 1, width: 1, height: 1)` 로
+// 직접 생성해도 native 호출이 일어나지 않으므로 unit test 안전.
+AssetEntity _fake(String id) => AssetEntity(
+      id: id,
+      typeInt: 1, // image
+      width: 100,
+      height: 100,
+    );
+
+void main() {
+  test('초기 state 는 빈 map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(selectedAssetsNotifierProvider), isEmpty);
+  });
+
+  test('setAssets — list → id 키 map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets([_fake('a'), _fake('b')]);
+
+    final state = container.read(selectedAssetsNotifierProvider);
+    expect(state.keys, ['a', 'b']);
+    expect(state['a']!.id, 'a');
+    expect(state['b']!.id, 'b');
+  });
+
+  test('setAssets — 빈 리스트 → 빈 map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets(const []);
+    expect(container.read(selectedAssetsNotifierProvider), isEmpty);
+  });
+
+  test('setAssets — 동일 id 중복 → 후입력 우선 (last-wins)', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    final first = _fake('x');
+    final second = _fake('x'); // 같은 id 의 다른 인스턴스
+    notifier.setAssets([first, second]);
+
+    final state = container.read(selectedAssetsNotifierProvider);
+    expect(state.length, 1);
+    expect(identical(state['x'], second), isTrue,
+        reason: 'Map literal 의 last-wins 시맨틱과 일관');
+  });
+
+  test('state map 은 수정 불가', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets([_fake('a')]);
+    final state = container.read(selectedAssetsNotifierProvider);
+
+    expect(() => state['b'] = _fake('b'), throwsUnsupportedError);
+  });
+}
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `flutter test test/features/suggestion/providers/selected_assets_provider_test.dart`
+Expected: FAIL — `selectedAssetsNotifierProvider` 가 정의되지 않음.
+
+- [ ] **Step 1.3: Write provider**
+
+`lib/features/suggestion/providers/selected_assets_provider.dart`:
+
+```dart
+import 'package:photo_manager/photo_manager.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'selected_assets_provider.g.dart';
+
+/// picker → suggestion 흐름 동안 `Map<String, AssetEntity>` 보존.
+///
+/// `flowSelectionProvider` 와 페어로 picker `_onNext` 에서 채워짐.
+/// `_MappedThumb` 가 cellId → assetId → AssetEntity 를 해석할 때 lookup.
+///
+/// `keepAlive: true` — picker 라우트 떠난 직후 microtask 에서도 state 가
+/// 살아있어야 suggestion 화면이 처음 build 될 때 빈 map 으로 떨어지지 않음.
+/// (`flowSelectionProvider` 와 동일한 라이프사이클.)
+@Riverpod(keepAlive: true)
+class SelectedAssetsNotifier extends _$SelectedAssetsNotifier {
+  @override
+  Map<String, AssetEntity> build() => const {};
+
+  /// `id → AssetEntity` 로 정규화. List 의 순서는 알고리즘 입력
+  /// (`flow.media`) 에서만 의미 있고, 본 provider 는 lookup 용이라 Map.
+  /// `Map.unmodifiable` 로 외부 mutation 차단.
+  void setAssets(List<AssetEntity> items) =>
+      state = Map.unmodifiable({for (final a in items) a.id: a});
+}
+```
+
+- [ ] **Step 1.4: Trigger codegen** (watch 가 안 돌고 있는 경우만)
+
+Run: `dart run build_runner build --delete-conflicting-outputs`
+Expected: `selected_assets_provider.g.dart` 생성.
+
+- [ ] **Step 1.5: Run test to verify it passes**
+
+Run: `flutter test test/features/suggestion/providers/selected_assets_provider_test.dart`
+Expected: PASS — 5 케이스 모두 green.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add lib/features/suggestion/providers/selected_assets_provider.dart \
+  lib/features/suggestion/providers/selected_assets_provider.g.dart \
+  test/features/suggestion/providers/selected_assets_provider_test.dart
+git commit -m "feat : SelectedAssetsNotifier provider 추가 (#5)"
+```
+
+---
+
+## Task 2: `ThumbnailLoader` 어댑터 + Riverpod provider
+
+추상 인터페이스 + photo_manager 위임 구현 + Riverpod provider. Fake 는 Task 5 의 `_MappedThumb` 위젯 테스트에서 사용. 본 Task 는 인터페이스/구현/provider 만 만들고 단위 테스트 X (위임 1줄이라 의미 있는 단위 검증 없음 — fake 사용은 Task 5 통합 테스트로 대체).
+
+**Files:**
+- Create: `lib/features/suggestion/providers/thumbnail_loader.dart`
+
+- [ ] **Step 2.1: Write file**
+
+```dart
+import 'dart:typed_data';
+
+import 'package:photo_manager/photo_manager.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'thumbnail_loader.g.dart';
+
+/// photo_manager 의 `thumbnailDataWithSize` 호출을 1점에 격리.
+///
+/// 테스트는 `thumbnailLoaderProvider.overrideWith((_) => FakeLoader(...))`
+/// 로 주입.
+abstract class ThumbnailLoader {
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size});
+}
+
+/// 프로덕션 구현 — photo_manager 직접 위임.
+class PhotoManagerThumbnailLoader implements ThumbnailLoader {
+  const PhotoManagerThumbnailLoader();
+
+  @override
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size}) =>
+      asset.thumbnailDataWithSize(size);
+}
+
+/// `keepAlive: true` — 어댑터 자체는 stateless 라 dispose 로 잃을 게 없지만
+/// 매번 new 하지 않게 하려고 keepAlive.
+@Riverpod(keepAlive: true)
+ThumbnailLoader thumbnailLoader(Ref ref) =>
+    const PhotoManagerThumbnailLoader();
+```
+
+- [ ] **Step 2.2: Trigger codegen**
+
+Run: `dart run build_runner build --delete-conflicting-outputs`
+Expected: `thumbnail_loader.g.dart` 생성.
+
+- [ ] **Step 2.3: Sanity build**
+
+Run: `flutter analyze lib/features/suggestion/providers/thumbnail_loader.dart`
+Expected: `No issues found!`
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add lib/features/suggestion/providers/thumbnail_loader.dart \
+  lib/features/suggestion/providers/thumbnail_loader.g.dart
+git commit -m "feat : ThumbnailLoader 어댑터 + provider 추가 (#5)"
+```
+
+---
+
+## Task 3: `icon_play.svg` 자산 추가 + pubspec 등록
+
+영상 셀 우상단 ▶ 인디케이터 자산. 16px 박스 안에 채워진 삼각형 단순 svg.
+
+**Files:**
+- Create: `assets/icons/icon_play.svg`
+- Modify: `pubspec.yaml`
+
+- [ ] **Step 3.1: Confirm 디렉터리 등록 상태**
+
+Run: `grep -n "assets/icons" pubspec.yaml`
+Expected: 디렉터리 / 파일 명시 등록 형태 확인. 현재 `pubspec.yaml` 의 `assets:` 섹션에 `assets/icons/` 디렉터리는 등록되어 있지 않을 수 있음 (`icon_block.svg` 등이 있는데도 등록 X 라면 다른 mechanism — 확인 필요).
+
+확인 결과에 따라:
+- `assets/icons/` 가 이미 등록 → Step 3.3 으로
+- 미등록 → 개별 파일 등록 (`pubspec.yaml` 의 기존 `assets/wordmark.svg` 식 패턴)
+
+- [ ] **Step 3.2: Write svg**
+
+`assets/icons/icon_play.svg`:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <path d="M5 3.5 L5 12.5 L12 8 Z" fill="currentColor"/>
+</svg>
+```
+
+(`currentColor` 로 두면 `SvgPicture.asset(..., colorFilter: ColorFilter.mode(AppColors.offWhite, BlendMode.srcIn))` 로 색 주입 가능.)
+
+- [ ] **Step 3.3: pubspec 등록 (Step 3.1 결과에 따라)**
+
+기존 패턴이 개별 파일이면, `pubspec.yaml` 의 `assets:` 아래 추가:
+
+```yaml
+    - assets/icons/icon_play.svg
+```
+
+- [ ] **Step 3.4: 자산 적재 확인**
+
+Run: `flutter pub get && flutter analyze`
+Expected: `No issues found!` + svg 파일 빌드 시 누락 경고 없음.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add assets/icons/icon_play.svg pubspec.yaml
+git commit -m "feat : icon_play.svg 자산 추가 (#5)"
+```
+
+---
+
+## Task 4: `photo_picker._onNext` 페어 호출 (`setMedia` + `setAssets`)
+
+picker `_onNext` 가 기존 `flowSelectionProvider.setMedia` 호출 옆에 `selectedAssetsProvider.setAssets` 를 페어로 추가.
+
+**Files:**
+- Modify: `lib/features/photo_picker/photo_picker_page.dart` (`_onNext` 메서드)
+- Modify: `test/features/photo_picker/photo_picker_page_test.dart` (페어 호출 검증 추가)
+
+- [ ] **Step 4.1: Write failing test (페어 호출 검증)**
+
+`test/features/photo_picker/photo_picker_page_test.dart` 의 `void main() { ... }` 끝에 케이스 추가:
+
+```dart
+  test('_onNext 페어 호출 — setMedia 와 setAssets 가 함께 호출됨', () async {
+    // photo_picker_page 내부 _onNext 는 private 이라 직접 호출 불가.
+    // ProviderContainer 에서 flow + selectedAssets 두 provider 가
+    // 동일 List<AssetEntity> source 로 동기 채워졌는지 검증.
+
+    final container = ProviderContainer(overrides: [
+      photoPermissionProvider
+          .overrideWith((ref) async => AppPermissionState.authorized),
+    ]);
+    addTearDown(container.dispose);
+
+    // ===== 시뮬레이션: _onNext 가 호출하는 두 setter 를 직접 호출 =====
+    // 본 테스트는 "두 setter 가 묶여 있음" 의 contract 만 검증한다.
+    // 실 위젯 통합 테스트는 native 의존이라 여기 범위 밖.
+    final assets = [
+      AssetEntity(id: 'p1', typeInt: 1, width: 100, height: 100),
+      AssetEntity(id: 'p2', typeInt: 1, width: 100, height: 100),
+    ];
+
+    final items = assets
+        .map(assetToMediaItem)
+        .whereType<MediaItem>()
+        .toList(growable: false);
+
+    container.read(flowSelectionNotifierProvider.notifier).setMedia(items);
+    container
+        .read(selectedAssetsNotifierProvider.notifier)
+        .setAssets(assets);
+
+    expect(
+      container.read(flowSelectionNotifierProvider).media.map((m) => m.id),
+      ['p1', 'p2'],
+      reason: 'flow.media 가 채워짐',
+    );
+    expect(
+      container.read(selectedAssetsNotifierProvider).keys,
+      ['p1', 'p2'],
+      reason: 'selectedAssetsProvider 도 같은 source 로 채워짐',
+    );
+  });
+```
+
+상단 import 에 추가:
+
+```dart
+import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
+import 'package:gridset/features/photo_picker/asset_to_media_item.dart';
+import 'package:gridset/features/suggestion/providers/selected_assets_provider.dart';
+import 'package:gridset/flow/flow_selection_provider.dart';
+import 'package:photo_manager/photo_manager.dart';
+```
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+Run: `flutter test test/features/photo_picker/photo_picker_page_test.dart`
+Expected: 새 케이스 PASS (실은 setter 호출만 검증하므로 통과). **그러나 본 케이스의 진짜 검증은 `_onNext` 코드가 setAssets 호출하지 않으면 회귀 시 다른 위젯 테스트에서 selectedAssets 가 비어있어 fail**. 하단 Task 5 의 widget test 가 그 회귀 캐치.
+
+(즉 본 테스트는 contract-level 가드. Step 4.3 의 코드 변경은 추가 케이스로 직접 fail 검증되지 않지만, Task 5 의 mapped_thumb_test 가 의존하는 `_onNext` 의 페어 호출이 깨지면 Task 5 가 fail.)
+
+- [ ] **Step 4.3: `_onNext` 에 setAssets 추가**
+
+`lib/features/photo_picker/photo_picker_page.dart` 의 `_onNext`:
+
+```dart
+import '../suggestion/providers/selected_assets_provider.dart';
+```
+
+import 추가 후 `_onNext` 본문 변경:
+
+```dart
+  void _onNext(BuildContext context, WidgetRef ref) {
+    final assets = ref.read(assetSelectionNotifierProvider);
+    final items = assets
+        .map(assetToMediaItem)
+        .whereType<MediaItem>()
+        .toList(growable: false);
+
+    // 페어 호출 — flowSelection 은 알고리즘 입력 (MediaItem),
+    // selectedAssets 는 렌더링 자원 (AssetEntity). 둘 중 하나만 호출되면
+    // suggestion 화면이 silent 실패 (모든 셀 placeholder).
+    ref.read(flowSelectionNotifierProvider.notifier).setMedia(items);
+    ref
+        .read(selectedAssetsNotifierProvider.notifier)
+        .setAssets(assets);
+
+    context.push(RoutePaths.suggestion);
+  }
+```
+
+- [ ] **Step 4.4: Run all photo_picker tests**
+
+Run: `flutter test test/features/photo_picker/`
+Expected: 모든 케이스 PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add lib/features/photo_picker/photo_picker_page.dart \
+  test/features/photo_picker/photo_picker_page_test.dart
+git commit -m "feat : photo_picker._onNext 페어 호출 (setMedia+setAssets) (#5)"
+```
+
+---
+
+## Task 5: `_MappedThumb` 위젯 — TDD 6 케이스
+
+본 Task 가 가장 큼. SuggestionCard 시그니처 확장 (assetsById prop) 도 본 Task 에 포함 (그래야 _MappedThumb 가 호출 가능).
+
+**Files:**
+- Modify: `lib/features/suggestion/widgets/suggestion_card.dart` (SuggestionCard 시그니처 확장 + _MappedThumb inline 추가)
+- Create: `test/features/suggestion/widgets/mapped_thumb_test.dart`
+
+- [ ] **Step 5.1: Write failing test (6 케이스 + 추가)**
+
+`test/features/suggestion/widgets/mapped_thumb_test.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' hide Split;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gridset/cores/constants/app_colors.dart';
+import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
+import 'package:gridset/features/suggestion/providers/thumbnail_loader.dart';
+import 'package:gridset/features/suggestion/widgets/suggestion_card.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+class _FakeLoader implements ThumbnailLoader {
+  _FakeLoader({this.bytesById = const {}, this.failIds = const {}});
+  final Map<String, Uint8List> bytesById;
+  final Set<String> failIds;
+  int callCount = 0;
+
+  @override
+  Future<Uint8List?> load(AssetEntity asset,
+      {required ThumbnailSize size}) async {
+    callCount += 1;
+    if (failIds.contains(asset.id)) return null;
+    return bytesById[asset.id];
+  }
+}
+
+// 1×1 transparent PNG — 위젯이 Image.memory 로 렌더할 수 있는 가장 작은 byte.
+final Uint8List _kTinyPng = Uint8List.fromList([
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+  0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+]);
+
+AssetEntity _photo(String id) =>
+    AssetEntity(id: id, typeInt: 1, width: 100, height: 100);
+AssetEntity _video(String id) =>
+    AssetEntity(id: id, typeInt: 2, width: 100, height: 100);
+
+Widget _harness({
+  required Widget child,
+  required _FakeLoader loader,
+}) {
+  return ProviderScope(
+    overrides: [thumbnailLoaderProvider.overrideWith((_) => loader)],
+    child: ScreenUtilInit(
+      designSize: const Size(393, 852),
+      child: MaterialApp(home: Scaffold(body: child)),
+    ),
+  );
+}
+
+GridSuggestion _twoCellSuggestion({
+  String idA = 'a',
+  String idB = 'b',
+}) =>
+    GridSuggestion(
+      tree: Split(
+        axis: SplitAxis.vertical,
+        positions: const [0.5],
+        children: const [Leaf(0), Leaf(1)],
+      ),
+      mediaByCellId: {0: idA, 1: idB},
+      loss: 0.0,
+      templateName: 'test_2',
+    );
+
+void main() {
+  testWidgets('(a) 정상 매핑 → Image 노드, fit cover', (tester) async {
+    final loader = _FakeLoader(bytesById: {'a': _kTinyPng, 'b': _kTinyPng});
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final images = tester.widgetList<Image>(find.byType(Image));
+    expect(images, hasLength(2), reason: '두 leaf → 두 Image');
+    for (final img in images) {
+      expect(img.fit, BoxFit.cover);
+      expect(img.gaplessPlayback, isTrue);
+    }
+  });
+
+  testWidgets('(b) assetsById 누락 → placeholder 톤', (tester) async {
+    final loader = _FakeLoader();
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: const {}, // 매핑 누락
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsNothing);
+    final placeholders = tester.widgetList<Container>(
+      find.descendant(
+        of: find.byType(SuggestionCard),
+        matching: find.byType(Container),
+      ),
+    );
+    for (final c in placeholders) {
+      final dec = c.decoration as BoxDecoration?;
+      if (dec == null) continue;
+      expect(dec.color, AppColors.lightCream);
+    }
+    expect(loader.callCount, 0, reason: 'asset 없으면 loader 호출 X');
+  });
+
+  testWidgets('(c) loader 가 null → placeholder', (tester) async {
+    final loader = _FakeLoader(failIds: {'a', 'b'});
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsNothing);
+    expect(loader.callCount, 2);
+  });
+
+  testWidgets('(d) 영상 자산 → ▶ icon overlay', (tester) async {
+    final loader = _FakeLoader(bytesById: {'v': _kTinyPng});
+    final suggestion = GridSuggestion(
+      tree: const Leaf(0),
+      mediaByCellId: const {0: 'v'},
+      loss: 0.0,
+      templateName: 'test_1',
+    );
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: suggestion,
+        canvas: const CanvasRatio.square(),
+        assetsById: {'v': _video('v')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(
+      find.byWidgetPredicate((w) =>
+          w is SvgPicture &&
+          (w.bytesLoader.toString().contains('icon_play') ||
+              w.toString().contains('icon_play'))),
+      findsOneWidget,
+      reason: '영상 자산은 ▶ overlay 가 셀 위에 깔림',
+    );
+  });
+
+  testWidgets(
+      '(e) rebuild 후에도 동일 (cellId, asset) 에 대한 callCount == 1',
+      (tester) async {
+    final loader = _FakeLoader(bytesById: {'a': _kTinyPng, 'b': _kTinyPng});
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+    final initial = loader.callCount;
+    expect(initial, 2, reason: '셀 2개 × 1회');
+
+    // 같은 prop 으로 rebuild — _MappedThumb State 의 _future 가 그대로
+    // 유지되어 loader 재호출 없어야.
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(loader.callCount, initial,
+        reason: '동일 (cellId, asset) → didUpdateWidget 비교 후 재호출 X');
+  });
+
+  testWidgets('(f) asset 변경 시 callCount 증가', (tester) async {
+    final loader = _FakeLoader(
+      bytesById: {'a': _kTinyPng, 'b': _kTinyPng, 'a2': _kTinyPng},
+    );
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(idA: 'a'),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+    final before = loader.callCount;
+
+    // cell 0 의 assetId 가 a → a2 로 바뀜.
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(idA: 'a2'),
+        canvas: const CanvasRatio.square(),
+        assetsById: {
+          'a': _photo('a'),
+          'a2': _photo('a2'),
+          'b': _photo('b'),
+        },
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(loader.callCount, greaterThan(before),
+        reason: 'cell 0 의 asset 이 바뀌었으므로 재로드 1회 발생');
+  });
+}
+```
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+Run: `flutter test test/features/suggestion/widgets/mapped_thumb_test.dart`
+Expected: FAIL — `SuggestionCard` 가 `assetsById` prop 없음. 또는 컴파일 에러.
+
+- [ ] **Step 5.3: Write `SuggestionCard` + `_MappedThumb` 구현**
+
+`lib/features/suggestion/widgets/suggestion_card.dart` 전면 갱신:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+import '../../../cores/constants/app_colors.dart';
+import '../../../cores/constants/app_spacing.dart';
+import '../../../cores/grid_suggestor/grid_suggestor.dart';
+import '../../../cores/widgets/grid_layout/bsp_grid_layout.dart';
+import '../providers/thumbnail_loader.dart';
+
+/// 후보 카드 한 개 — BspGridLayout 위에 사진 썸네일 매핑.
+///
+/// `mediaByCellId` 로 cellId → assetId 해석, `assetsById` 로
+/// assetId → AssetEntity 해석 후 `_MappedThumb` 가 비동기 로드.
+class SuggestionCard extends StatelessWidget {
+  const SuggestionCard({
+    super.key,
+    required this.suggestion,
+    required this.canvas,
+    required this.assetsById,
+  });
+
+  final GridSuggestion suggestion;
+  final CanvasRatio canvas;
+  final Map<String, AssetEntity> assetsById;
+
+  @override
+  Widget build(BuildContext context) {
+    return BspGridLayout(
+      tree: suggestion.tree,
+      aspectRatio: canvas.value,
+      borderColor: AppColors.lightCream,
+      cellBuilder: (cellId, _) => _MappedThumb(
+        cellId: cellId,
+        mediaByCellId: suggestion.mediaByCellId,
+        assetsById: assetsById,
+      ),
+    );
+  }
+}
+
+/// 매핑된 셀 — id → AssetEntity → 썸네일 byte → Image.memory(cover).
+///
+/// stateful — `FutureBuilder` 가 매 rebuild 시 새 Future 를 받으면 한 프레임
+/// `waiting` 으로 떨어져 깜빡임 발생. State 가 future 를 1회 시작 후 보관.
+class _MappedThumb extends ConsumerStatefulWidget {
+  const _MappedThumb({
+    required this.cellId,
+    required this.mediaByCellId,
+    required this.assetsById,
+  });
+
+  final int cellId;
+  final Map<int, String> mediaByCellId;
+  final Map<String, AssetEntity> assetsById;
+
+  @override
+  ConsumerState<_MappedThumb> createState() => _MappedThumbState();
+}
+
+class _MappedThumbState extends ConsumerState<_MappedThumb> {
+  Future<Uint8List?>? _future;
+  AssetEntity? _asset;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveAndLoad();
+  }
+
+  @override
+  void didUpdateWidget(covariant _MappedThumb old) {
+    super.didUpdateWidget(old);
+    final prevId = old.mediaByCellId[old.cellId];
+    final nextId = widget.mediaByCellId[widget.cellId];
+    final prevAsset = prevId == null ? null : old.assetsById[prevId];
+    final nextAsset = nextId == null ? null : widget.assetsById[nextId];
+    if (prevId != nextId || !identical(prevAsset, nextAsset)) {
+      _resolveAndLoad();
+    }
+  }
+
+  void _resolveAndLoad() {
+    final assetId = widget.mediaByCellId[widget.cellId];
+    assert(assetId != null,
+        'mediaByCellId 에 cellId=${widget.cellId} 매핑 없음 — 알고리즘 계약 위반');
+    final asset = assetId == null ? null : widget.assetsById[assetId];
+    _asset = asset;
+    if (asset == null) {
+      if (assetId != null) {
+        debugPrint('⚠️ asset 누락 cellId=${widget.cellId} id=$assetId');
+      }
+      _future = null;
+      return;
+    }
+    _future = ref
+        .read(thumbnailLoaderProvider)
+        .load(asset, size: const ThumbnailSize.square(512));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asset = _asset;
+    final future = _future;
+    if (asset == null || future == null) {
+      return const _PlaceholderCell();
+    }
+    return FutureBuilder<Uint8List?>(
+      future: future,
+      builder: (context, snap) {
+        if (snap.connectionState == ConnectionState.waiting) {
+          return const _PlaceholderCell();
+        }
+        final bytes = snap.data;
+        if (snap.hasError || bytes == null) {
+          debugPrint(
+            '⚠️ thumb load 실패 cellId=${widget.cellId} '
+            'asset=${asset.id} err=${snap.error}',
+          );
+          return const _PlaceholderCell();
+        }
+        final image = Image.memory(
+          bytes,
+          fit: BoxFit.cover,
+          gaplessPlayback: true,
+        );
+        if (asset.type == AssetType.video) {
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              image,
+              Positioned(
+                top: AppSpacing.sm,
+                right: AppSpacing.sm,
+                child: _VideoIndicator(),
+              ),
+            ],
+          );
+        }
+        return image;
+      },
+    );
+  }
+}
+
+class _VideoIndicator extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 24,
+      height: 24,
+      decoration: const BoxDecoration(
+        color: AppColors.charcoal40,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: SvgPicture.asset(
+        'assets/icons/icon_play.svg',
+        width: 16,
+        height: 16,
+        colorFilter: const ColorFilter.mode(
+          AppColors.offWhite,
+          BlendMode.srcIn,
+        ),
+      ),
+    );
+  }
+}
+
+class _PlaceholderCell extends StatelessWidget {
+  const _PlaceholderCell();
+
+  @override
+  Widget build(BuildContext context) {
+    // spec(2026-04-27-mapped-thumb-design.md) §8 — 매핑 실패/대기 모두
+    // 동일 톤. 사용자에게 위협 톤 노출 X.
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.lightCream,
+        border: Border.all(color: AppColors.charcoal04),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 5.4: Run mapped_thumb test**
+
+Run: `flutter test test/features/suggestion/widgets/mapped_thumb_test.dart`
+Expected: 6 케이스 PASS.
+
+- [ ] **Step 5.5: Run all suggestion tests (회귀 확인)**
+
+Run: `flutter test test/features/suggestion/`
+Expected: 기존 `suggestion_card_test.dart` 가 새 `assetsById` 인자를 안 줘서 **컴파일 fail**. Task 6 에서 갱신.
+
+본 Task 는 mapped_thumb_test 만 green 인 상태에서 commit 진행 (다음 Task 가 즉시 그 fail 을 해결).
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add lib/features/suggestion/widgets/suggestion_card.dart \
+  test/features/suggestion/widgets/mapped_thumb_test.dart
+git commit -m "feat : _MappedThumb 위젯 + SuggestionCard 시그니처 확장 (#5)"
+```
+
+---
+
+## Task 6: 기존 `suggestion_card_test.dart` 갱신
+
+Task 5 에서 `SuggestionCard` 가 `assetsById` 를 require 받도록 바뀜 → 기존 placeholder 가정 테스트가 컴파일 실패. 두 길:
+
+(i) 기존 회귀 테스트 (placeholder 톤) 의 의도를 보존하기 위해 `assetsById: const {}` (매핑 누락) 케이스로 변형 — 같은 결과 (placeholder 톤 두 개) 가 나옴.
+(ii) 회귀 테스트를 mapped_thumb_test 의 케이스 (b) 가 흡수했다고 보고 케이스 삭제.
+
+**(i) 선택** — 기존 spec(2026-04-27-suggestion-flow-design.md) 의 placeholder 톤 회귀 가드는 별도 의미가 있어 보존.
+
+**Files:**
+- Modify: `test/features/suggestion/suggestion_card_test.dart`
+
+- [ ] **Step 6.1: Run test to confirm current failure**
+
+Run: `flutter test test/features/suggestion/suggestion_card_test.dart`
+Expected: 컴파일 에러 — `SuggestionCard` 가 `assetsById` 누락.
+
+- [ ] **Step 6.2: 갱신 — assetsById: const {} 케이스로 변형**
+
+`test/features/suggestion/suggestion_card_test.dart` 전면 갱신:
+
+```dart
+import 'package:flutter/material.dart' hide Split;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gridset/cores/constants/app_colors.dart';
+import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
+import 'package:gridset/features/suggestion/widgets/suggestion_card.dart';
+
+void main() {
+  // 회귀 방지 — spec(2026-04-27-suggestion-flow-design.md) 의
+  // "Suggestion v1: lightCream 배경 + charcoal04 border" 와 코드가 swap 되어
+  // 셀 분할이 cream 배경 위에서 시각적으로 사라졌던 사례.
+  //
+  // v1.x mapped-thumb-design 도입 후: assetsById 가 비어있는 fallback 경로에서도
+  // 동일한 placeholder 톤이 유지됨을 보증.
+  testWidgets(
+    'SuggestionCard — assetsById 누락 시 placeholder 톤 유지 (lightCream + charcoal04)',
+    (tester) async {
+      final suggestion = GridSuggestion(
+        tree: Split(
+          axis: SplitAxis.vertical,
+          positions: const [0.5],
+          children: const [Leaf(0), Leaf(1)],
+        ),
+        mediaByCellId: const {0: 'a', 1: 'b'},
+        loss: 0.0,
+        templateName: 'test_2',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: ScreenUtilInit(
+            designSize: const Size(393, 852),
+            child: MaterialApp(
+              home: Scaffold(
+                body: Center(
+                  child: SuggestionCard(
+                    suggestion: suggestion,
+                    canvas: const CanvasRatio.square(),
+                    assetsById: const {}, // 매핑 누락 — fallback 경로
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // _PlaceholderCell 의 Container 만 SuggestionCard 하위에 존재.
+      final containers = tester.widgetList<Container>(
+        find.descendant(
+          of: find.byType(SuggestionCard),
+          matching: find.byType(Container),
+        ),
+      );
+
+      // 두 leaf → 두 placeholder. (BspGridLayout 자체의 DecoratedBox 는
+      // Container 가 아니므로 제외됨.)
+      final withPlaceholderDecoration = containers.where((c) {
+        final dec = c.decoration;
+        return dec is BoxDecoration && dec.color == AppColors.lightCream;
+      });
+      expect(withPlaceholderDecoration, hasLength(2),
+          reason: 'leaf 마다 placeholder 한 개');
+
+      for (final c in withPlaceholderDecoration) {
+        final decoration = c.decoration as BoxDecoration;
+        final border = decoration.border as Border;
+        expect(
+          border.top.color,
+          AppColors.charcoal04,
+          reason: 'spec: charcoal04 분할선',
+        );
+        expect(border.left.color, AppColors.charcoal04);
+        expect(border.right.color, AppColors.charcoal04);
+        expect(border.bottom.color, AppColors.charcoal04);
+      }
+    },
+  );
+}
+```
+
+- [ ] **Step 6.3: Run test to verify pass**
+
+Run: `flutter test test/features/suggestion/suggestion_card_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6.4: Run all suggestion tests**
+
+Run: `flutter test test/features/suggestion/`
+Expected: 모든 케이스 PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add test/features/suggestion/suggestion_card_test.dart
+git commit -m "test : suggestion_card_test 갱신 — assetsById 누락 케이스 (#5)"
+```
+
+---
+
+## Task 7: `SuggestionPage` 수정 (selectedAssetsProvider watch + assetsById prop + allowImplicitScrolling)
+
+**Files:**
+- Modify: `lib/features/suggestion/suggestion_page.dart`
+- Modify: `test/features/suggestion/suggestion_page_test.dart` (필요 시 — provider 주입 추가)
+
+- [ ] **Step 7.1: 기존 suggestion_page_test 확인**
+
+Run: `flutter test test/features/suggestion/suggestion_page_test.dart`
+Expected: 컴파일/런 fail 가능 (Task 5 후 SuggestionCard 가 assetsById 요구).
+
+- [ ] **Step 7.2: SuggestionPage 변경**
+
+`lib/features/suggestion/suggestion_page.dart` 의 `_Loaded.build` 안 PageView.builder 변경 + `_Loaded` 가 assetsById 받도록:
+
+먼저 import 추가:
+
+```dart
+import 'providers/selected_assets_provider.dart';
+```
+
+`_SuggestionPageState.build` 안에서 watch 추가:
+
+```dart
+    final state = ref.watch(suggestionNotifierProvider);
+    final assetsById = ref.watch(selectedAssetsNotifierProvider);
+```
+
+`_Loaded` 호출에 prop 추가:
+
+```dart
+          SuggestionStateLoaded() => _Loaded(
+              state: state,
+              assetsById: assetsById,        // ← 신규
+              controller: _controller,
+              onPageChanged: (i) =>
+                  ref.read(suggestionNotifierProvider.notifier).selectIndex(i),
+              onPick: () => _stub(context, '에디터는 곧 준비됩니다'),
+              onMore: state.cursor == null
+                  ? null
+                  : () {
+                      ref
+                          .read(suggestionNotifierProvider.notifier)
+                          .loadMore();
+                    },
+              onBlank: () => _stub(context, '에디터는 곧 준비됩니다'),
+            ),
+```
+
+`_Loaded` 클래스 시그니처 + PageView.builder 변경:
+
+```dart
+class _Loaded extends StatelessWidget {
+  const _Loaded({
+    required this.state,
+    required this.assetsById,
+    required this.controller,
+    required this.onPageChanged,
+    required this.onPick,
+    required this.onMore,
+    required this.onBlank,
+  });
+
+  final SuggestionStateLoaded state;
+  final Map<String, AssetEntity> assetsById;
+  final PageController controller;
+  final ValueChanged<int> onPageChanged;
+  final VoidCallback onPick;
+  final VoidCallback? onMore;
+  final VoidCallback onBlank;
+  ...
+```
+
+`AssetEntity` import 필요:
+
+```dart
+import 'package:photo_manager/photo_manager.dart';
+```
+
+PageView.builder 안:
+
+```dart
+        Expanded(
+          child: PageView.builder(
+            controller: controller,
+            allowImplicitScrolling: true,    // ← 신규: 인접 1장 preload
+            onPageChanged: onPageChanged,
+            itemCount: state.suggestions.length,
+            itemBuilder: (_, i) {
+              final selected = i == state.selectedIndex;
+              return Padding(
+                padding: EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 200),
+                  opacity: selected ? 1.0 : 0.5,
+                  child: SuggestionCard(
+                    suggestion: state.suggestions[i],
+                    canvas: state.canvas,
+                    assetsById: assetsById,       // ← 신규
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+```
+
+- [ ] **Step 7.3: suggestion_page_test 갱신 (필요 시)**
+
+기존 테스트가 SuggestionState.loaded 를 직접 주입한다면 selectedAssetsProvider 도 함께 주입 필요. 현재 테스트 파일 검토:
+
+Run: `cat test/features/suggestion/suggestion_page_test.dart`
+
+- 만약 ProviderScope override 가 이미 있고 SuggestionStateLoaded 시나리오가 있다면, override 에 `selectedAssetsNotifierProvider.overrideWith` 추가.
+- 권한 화면만 검증하는 테스트라면 변경 불필요.
+
+수정이 필요한 경우 — 예시 (시나리오에 따라):
+
+```dart
+// ProviderScope overrides 에 추가:
+selectedAssetsNotifierProvider.overrideWith(() {
+  return _StubNotifier();
+}),
+```
+
+(실제 테스트 코드를 보고 적합하게 적용. 단순 권한 분기만 검증 중이면 변경 불요.)
+
+- [ ] **Step 7.4: Run all suggestion + flow tests**
+
+Run: `flutter test test/features/suggestion/ test/flow/`
+Expected: 모든 케이스 PASS.
+
+- [ ] **Step 7.5: Run analyze**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add lib/features/suggestion/suggestion_page.dart \
+  test/features/suggestion/suggestion_page_test.dart
+git commit -m "feat : SuggestionPage assetsById watch + PageView preload (#5)"
+```
+
+---
+
+## Task 8: spec cross-link 갱신
+
+기존 `2026-04-27-suggestion-flow-design.md` §"GridTemplatePreview 승격" 표 v1.x 행 = 완료 ✓ + 본 spec cross-link.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-27-suggestion-flow-design.md`
+
+- [ ] **Step 8.1: Locate v1.x row**
+
+Run: `grep -n "v1.x\|MappedThumb\|사진 썸네일 매핑" docs/superpowers/specs/2026-04-27-suggestion-flow-design.md`
+Expected: 약 line 578 부근 의 표 행.
+
+- [ ] **Step 8.2: 행 업데이트**
+
+`| 사진 썸네일 매핑 (v1.x) | ... |` 행을 다음과 같이 갱신 (정확한 형식은 기존 표 칼럼 수에 맞춤):
+
+```
+| 사진 썸네일 매핑 (v1.x) ✓ | `BspGridLayout.cellBuilder` 를 `_PlaceholderCell` → `_MappedThumb(asset:...)` 로 swap. 자세한 spec: [`2026-04-27-mapped-thumb-design.md`](./2026-04-27-mapped-thumb-design.md) |
+```
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-27-suggestion-flow-design.md
+git commit -m "docs : suggestion-flow-design v1.x 완료 표시 + cross-link (#5)"
+```
+
+---
+
+## Task 9: 최종 회귀 + 분석 + 매뉴얼 시각 검증
+
+**Files:** 없음 (실행만)
+
+- [ ] **Step 9.1: 전체 테스트**
+
+Run: `flutter test`
+Expected: 전체 PASS.
+
+- [ ] **Step 9.2: analyze**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 9.3: 디바이스/시뮬레이터 매뉴얼 검증**
+
+iOS 시뮬레이터 또는 실 기기 (사진 권한 필수):
+
+1. 앱 실행 → 홈 → "그리드 만들기"
+2. canvas-picker → 비율 선택 (예: 1:1)
+3. photo-picker → 권한 허용 → 사진 4~5장 선택 → "다음"
+4. suggestion 화면 진입 — 카드마다 셀에 실제 사진 썸네일이 또렷이 보이는지 확인
+5. PageView swipe — 인접 카드도 즉시 채워져 깜빡임 없는지 확인 (allowImplicitScrolling 효과)
+6. 영상이 섞여있다면 우상단 ▶ 인디케이터 노출 확인
+7. fit cover — 사진 잘림이 자연스러운지 (letterbox 없음) 확인
+
+만약 시각적 이상이 있으면 Phase D 후속 PR 의 입력으로 메모.
+
+- [ ] **Step 9.4: PR 생성 (사용자 승인 후)**
+
+`CLAUDE.md` 가 `git push 절대 금지` 라 본 단계는 사용자 명시 요청 시에만. 본 plan 의 default 는 commit 까지만.
+
+---
+
+## Out of Scope (본 PR 비포함)
+
+이슈 §검토 변수 / spec §11 와 일치:
+- ❌ Phase D 큐레이션 시각 iterate (별 PR — Step 9.3 결과로 ugly template 발견 시 후속 작업)
+- ❌ 셀 내 미디어 long-press / pinch-zoom (F06)
+- ❌ 영상 재생 / 자동 싱크 (F07)
+- ❌ PNG 저장 (F08)
+- ❌ photo_manager 외 추가 LRU 캐시
+- ❌ duration 텍스트 노출 (F07 spec 시 재검토)
+
+---
+
+## Self-Review Notes (작성자 확인용)
+
+**Spec coverage:**
+- §1 결정 요약 9개 항목 모두 Task 매핑 (1→1, 2→2, 3→Task 5 PageView 단 — fit/size/preload, 4→2/3/5, 6→5, 7→ Phase D 별도, 8→2/5, 9→8/spec 본 plan 자체).
+- §2 아키텍처 — Task 1, 2, 5, 7 합산.
+- §3 데이터 흐름 — Task 4 (페어 호출).
+- §4 _MappedThumb 명세 — Task 5.
+- §5 ThumbnailLoader — Task 2.
+- §6 영상 인디케이터 — Task 3 + 5.
+- §7 PageView preload — Task 7.
+- §8 fallback 매트릭스 — Task 5 의 (b)(c) 케이스.
+- §9 테스트 단위 — Task 1, 4, 5, 6 분배.
+- §10 변경 파일 — Task 1~7 합산.
+- §11 비범위 — Out of Scope 섹션.
+- §12 후속 hooks — 본 plan 비포함, spec 자체 보존.
+
+**Placeholder scan:** `<issue-num>` 만 의도적 placeholder (실행 직전 GitHub 이슈 등록 후 치환).
+
+**Type consistency:**
+- `selectedAssetsNotifierProvider` — Task 1 정의, Task 4 / 7 사용.
+- `thumbnailLoaderProvider` — Task 2 정의, Task 5 override.
+- `SuggestionCard.assetsById` — Task 5 시그니처 추가, Task 6 / 7 호출.
+- `_MappedThumb({cellId, mediaByCellId, assetsById})` — Task 5 일관.
+- `ThumbnailSize.square(512)` — spec §1 / Task 5 일관.

--- a/docs/superpowers/plans/2026-04-27-mapped-thumb.md
+++ b/docs/superpowers/plans/2026-04-27-mapped-thumb.md
@@ -17,6 +17,7 @@
 ## File Map
 
 ### 신규
+
 | 파일 | 책임 |
 |---|---|
 | `lib/features/suggestion/providers/selected_assets_provider.dart` (+ `.g.dart`) | `Map<String, AssetEntity>` 보존 (keepAlive) |
@@ -26,6 +27,7 @@
 | `test/features/suggestion/widgets/mapped_thumb_test.dart` | `_MappedThumb` 분기 6 케이스 |
 
 ### 수정
+
 | 파일 | 변경 |
 |---|---|
 | `lib/features/suggestion/widgets/suggestion_card.dart` | `assetsById` prop 추가, `cellBuilder` 를 `_MappedThumb` 로 교체. `_PlaceholderCell` 은 fallback 용 private 유지. `_MappedThumb` 는 inline private |
@@ -1167,7 +1169,7 @@ Expected: 약 line 578 부근 의 표 행.
 
 `| 사진 썸네일 매핑 (v1.x) | ... |` 행을 다음과 같이 갱신 (정확한 형식은 기존 표 칼럼 수에 맞춤):
 
-```
+```markdown
 | 사진 썸네일 매핑 (v1.x) ✓ | `BspGridLayout.cellBuilder` 를 `_PlaceholderCell` → `_MappedThumb(asset:...)` 로 swap. 자세한 spec: [`2026-04-27-mapped-thumb-design.md`](./2026-04-27-mapped-thumb-design.md) |
 ```
 

--- a/docs/superpowers/specs/2026-04-27-mapped-thumb-design.md
+++ b/docs/superpowers/specs/2026-04-27-mapped-thumb-design.md
@@ -1,0 +1,368 @@
+# Suggestion 사진 썸네일 매핑 (`_MappedThumb`) — Design Spec
+
+**Date:** 2026-04-27
+**Scope:** Suggestion 화면 (`SuggestionCard`) 의 셀 빌더를 `_PlaceholderCell` 에서 `_MappedThumb` 로 교체. `GridSuggestion.mediaByCellId` (cellId → MediaItem.id) 매핑을 실제 사진/영상 첫 프레임 썸네일로 시각화. PRD §F00 자동 레이아웃 제안의 "후보 비교" 단계가 의미를 갖도록 만든다.
+**Constraint:** 온디바이스. 외부 호출 없음. `photo_manager` / `photo_manager_image_provider` 만 사용. 코어 (`lib/cores/grid_suggestor/`) 의존성 변동 없음 — 본 작업은 `features/suggestion/` 한정.
+**Source:** `docs/PRD.md` §F00, §9-2-4 (편집 0). `.issues/20260427_기능추가_Suggestion_사진_썸네일_매핑.md`.
+**Depends on:** `docs/superpowers/specs/2026-04-27-suggestion-flow-design.md` (Suggestion 화면 골격 — main 머지 완료).
+**Consumed by (post-spec):** Phase D 큐레이션 시각 iterate (별 PR), F08 PNG 저장 (Editor sprint), F06 셀 내 미디어 조작 (Editor sprint), F07 영상 자동 싱크 (별 sprint).
+
+---
+
+## 1. 결정 요약
+
+| # | 항목 | 결정 | 근거 |
+|---|---|---|---|
+| 1 | AssetEntity 입수 경로 | 신규 `selectedAssetsProvider` (keepAlive: true). picker `_onNext` 가 `setMedia` 와 페어로 `setAssets` 호출 | flow 의 도메인은 "알고리즘 입력 (MediaItem)", assets 는 "렌더링 자원" — 분리. cores/flow 가 photo_manager 에 직접 의존하지 않음 |
+| 2 | fit 모드 | `BoxFit.cover` 고정 | "편집 0" 철학과 인스타 그리드 인상. cell ↔ media AR 차이는 알고리즘이 최소화하므로 잘림은 통상 작음. F06 진입 시 사용자가 변경 |
+| 3 | 썸네일 사이즈 | `ThumbnailSize.square(512)` 고정 | N=2 split 셀(화면 절반 ≈ 585px) 도 또렷. 9셀 × 3카드 ≈ 27MB cap. 본 화면은 미리보기라 저장 화질과 무관 — F08 의 RepaintBoundary pixelRatio 정책은 별 spec |
+| 4 | 영상 셀 표시 | 첫 프레임 still + 우상단 16px ▶ 인디케이터 | `AssetEntityImage` / `thumbnailDataWithSize` 가 video 에 대해 native first-frame 반환. 인디케이터는 인스타·갤러리 표준 패턴 |
+| 5 | preload 범위 | `PageView.allowImplicitScrolling: true` (인접 1장) | swipe 직후 빈 셀 깜빡임 제거. 메모리 영향 미미 (9셀 × 1장 추가) |
+| 6 | 매핑 실패 fallback | `_PlaceholderCell` 톤 그대로 + `debugPrint` 한 줄 | 권한 limited 자동 변경처럼 사용자 책임 외 케이스가 다수 — 위협 톤 부적절. picker 미선택 셀 톤과 일관 |
+| 7 | Phase D 큐레이션 시각 iterate | **본 PR 비포함**, 후속 PR 로 분리 | UI 코드 변경과 큐레이션(template entry + 골든) 변경의 의도 분리. 시각 판단 round-trip 으로 본 PR 머지 지연 방지 |
+| 8 | 단위 테스트 모킹 | `ThumbnailLoader` 추상 어댑터 + `FakeThumbnailLoader` 주입 | `assetToMediaItem` 어댑터 패턴과 일관. photo_manager 네이티브 의존을 1점에 격리 |
+| 9 | spec 위치 | 본 파일 (`2026-04-27-mapped-thumb-design.md`). 기존 `suggestion-flow-design.md` §"GridTemplatePreview 승격" 표 v1.x 행은 구현 PR 시점에 cross-link 갱신 | brainstorming skill 의 `YYYY-MM-DD-<topic>-design.md` 패턴. 후속 (Phase D / F06 / F08) 도 토픽별 spec 으로 독립 |
+
+---
+
+## 2. 아키텍처
+
+### 2-1. 컴포넌트 트리
+
+```
+photo_picker route (기존)
+└─ _onNext()
+   ├─ flowSelectionProvider.setMedia(items: List<MediaItem>)   (기존)
+   └─ selectedAssetsProvider.setAssets(items: List<AssetEntity>)  ← 신규
+
+suggestion route
+└─ SuggestionPage
+   ├─ ref.watch(suggestionNotifierProvider)         (기존)
+   ├─ ref.watch(selectedAssetsProvider)             (신규)
+   └─ PageView.builder(allowImplicitScrolling: true, ...)
+      └─ SuggestionCard(suggestion, canvas, assetsById)
+         └─ BspGridLayout(
+              cellBuilder: (cellId, _) => _MappedThumb(
+                cellId: cellId,
+                mediaByCellId: suggestion.mediaByCellId,
+                assetsById: assetsById,
+              ))
+```
+
+### 2-2. 책임 분리
+
+| 레이어 | 책임 | 비책임 |
+|---|---|---|
+| `selectedAssetsProvider` | id → AssetEntity Map 보존 (picker 라우트 떠난 후에도) | 알고리즘 입력 변환 (= flow 의 책임) |
+| `SuggestionCard` | suggestion + assetsById prop 받아 BspGridLayout 에 cellBuilder 위임 | 비동기 로드 / 실패 분기 (`_MappedThumb` 안쪽) |
+| `_MappedThumb` | cellId 에서 asset 해석 + 비동기 로드 + 3분기 (성공/실패/대기) | 셀 위치/크기 (= `BspGridLayout` 책임) |
+| `ThumbnailLoader` | photo_manager API 1점 격리 | 캐싱 정책 (현재는 photo_manager 자체 캐시 의존) |
+
+### 2-3. 의존성 흐름
+
+```
+features/suggestion ──depends──▶ cores/grid_suggestor (배럴, 기존)
+features/suggestion ──depends──▶ photo_manager (신규 / suggestion 영역 한정)
+features/photo_picker ──depends──▶ flow + suggestion.providers.selected_assets  (신규)
+flow/, cores/grid_suggestor/ ──┃ photo_manager 의존성 0 유지 (기존 정책 보존)
+```
+
+---
+
+## 3. 데이터 흐름
+
+```
+[picker] AssetSelectionNotifier (List<AssetEntity>, keepAlive: false)
+              │ _onNext()
+              ▼
+        +─── 분기 (페어 호출) ───+
+        ▼                       ▼
+flowSelectionProvider     selectedAssetsProvider          ← 신규
+  setMedia(items)            setAssets(items)
+  (List<MediaItem>)          (Map<String, AssetEntity>)
+        │                       │
+        ▼                       ▼
+[suggestion route 로 push]
+              │
+              ▼
+suggestionNotifier (suggest 호출)
+  → suggestions[i].mediaByCellId  (cellId → assetId)
+              │
+              ▼
+SuggestionPage build
+  ─ assetsById = ref.watch(selectedAssetsProvider)
+  ─ each card → cellBuilder(cellId)
+    └─ _MappedThumb 가
+       1) assetId = mediaByCellId[cellId]                      (sync)
+       2) asset   = assetsById[assetId]                        (sync)
+       3) loader.load(asset, ThumbnailSize.square(512))        (async)
+       4) Image.memory(bytes, fit: cover) + ▶ if video         (sync)
+```
+
+### 3-1. 페어 호출 보장
+
+`setMedia` 와 `setAssets` 둘 중 하나만 호출되는 경우 (예: 미래 코드 변경) 본 화면이 silent 실패 (모든 셀 placeholder). 이를 막기 위해:
+
+- picker `_onNext` 에서 두 호출을 **순서 고정** 으로 묶음 (`setMedia` → `setAssets`).
+- 단위 테스트로 페어 호출 contract 검증 (`photo_picker_page_test.dart` 확장).
+- 향후 `setMedia` 만 호출하는 경로가 추가될 가능성을 차단하기 위해 spec §6 비범위에 "MediaItem ↔ AssetEntity 페어 깨지는 변경 금지" 명시.
+
+### 3-2. `selectedAssetsProvider` 시그니처
+
+```dart
+@Riverpod(keepAlive: true)
+class SelectedAssetsNotifier extends _$SelectedAssetsNotifier {
+  @override
+  Map<String, AssetEntity> build() => const {};
+
+  /// id → AssetEntity 맵으로 변환해 보존. List 의 순서는 알고리즘 입력 (flow.media)
+  /// 에서만 의미 있고 본 provider 는 lookup 용이므로 Map 으로 정규화.
+  void setAssets(List<AssetEntity> items) =>
+      state = Map.unmodifiable({for (final a in items) a.id: a});
+}
+```
+
+`keepAlive: true` 근거: `flowSelectionProvider` 와 동일한 라이프사이클. picker → suggestion 라우트 전환 사이의 microtask 동안 state 가 살아있어야 함 (`flow_selection_provider.dart` 가 같은 이유로 keepAlive 적용).
+
+---
+
+## 4. `_MappedThumb` 명세
+
+### 4-1. 인터페이스
+
+`_MappedThumb` 는 **`ConsumerStatefulWidget`** 으로 만든다. 이유: `FutureBuilder` 가 매 rebuild 시 새 Future 를 받으면 한 프레임 `waiting` 으로 떨어져 깜빡임 발생 (PageView preload + `gaplessPlayback` 으로도 차단 안 됨). State 안에서 future 를 1회만 시작하고 의존 입력이 바뀔 때만 재생성한다.
+
+```dart
+class _MappedThumb extends ConsumerStatefulWidget {
+  const _MappedThumb({
+    required this.cellId,
+    required this.mediaByCellId,
+    required this.assetsById,
+  });
+
+  final int cellId;
+  final Map<int, String> mediaByCellId;
+  final Map<String, AssetEntity> assetsById;
+
+  @override
+  ConsumerState<_MappedThumb> createState() => _MappedThumbState();
+}
+
+class _MappedThumbState extends ConsumerState<_MappedThumb> {
+  late Future<Uint8List?>? _future;
+  AssetEntity? _asset;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveAndLoad();
+  }
+
+  @override
+  void didUpdateWidget(covariant _MappedThumb old) {
+    super.didUpdateWidget(old);
+    final prevId = old.mediaByCellId[old.cellId];
+    final nextId = widget.mediaByCellId[widget.cellId];
+    if (prevId != nextId || old.assetsById[prevId] != widget.assetsById[nextId]) {
+      _resolveAndLoad();
+    }
+  }
+
+  void _resolveAndLoad() {
+    final assetId = widget.mediaByCellId[widget.cellId];
+    final asset = assetId == null ? null : widget.assetsById[assetId];
+    _asset = asset;
+    _future = asset == null
+        ? null
+        : ref
+            .read(thumbnailLoaderProvider)
+            .load(asset, size: const ThumbnailSize.square(512));
+  }
+}
+```
+
+### 4-2. 빌드 분기
+
+| 분기 | 조건 | 결과 |
+|---|---|---|
+| ① 계약 위반 | `mediaByCellId[cellId] == null` | `_PlaceholderCell` + `assert` (debug) + `debugPrint` |
+| ② asset 사라짐 | `assetsById[assetId] == null` | `_PlaceholderCell` + `debugPrint('⚠️ asset 누락 cellId=$cellId id=$assetId')` |
+| ③ 로딩 중 | `FutureBuilder` `ConnectionState.waiting` | `_PlaceholderCell` (인디케이터 0 — 깜빡임 방지) |
+| ④ 로드 실패 | `snapshot.hasError` 또는 `snapshot.data == null` | `_PlaceholderCell` + `debugPrint('⚠️ thumb load 실패 cellId=$cellId asset=$assetId err=$err')` |
+| ⑤ 성공 사진 | data 있음 + `asset.type == AssetType.image` | `Image.memory(bytes, fit: BoxFit.cover, gaplessPlayback: true)` |
+| ⑥ 성공 영상 | data 있음 + `asset.type == AssetType.video` | ⑤ + 우상단 ▶ overlay |
+
+`gaplessPlayback: true` — 같은 위젯이 다른 byte 로 rebuild 될 때 한 프레임 빈 화면 방지 (PageView preload 와 시너지).
+
+### 4-3. Future 라이프사이클
+
+`_MappedThumb` 는 stateful (§4-1) 로 future 를 **State 가 보유**. 호출 시점:
+
+| 시점 | 동작 |
+|---|---|
+| `initState` | `_resolveAndLoad()` 1회 호출 → `_future` 채움 |
+| `didUpdateWidget` | `(cellId, mediaByCellId, assetsById)` 가 결정하는 asset 동일성 비교. 다르면 재로드, 같으면 보존 |
+| `build` | 보유한 `_future` 를 `FutureBuilder.future` 로 그대로 전달. rebuild 가 일어나도 future 객체가 유지되어 `FutureBuilder` 가 waiting 으로 떨어지지 않음 |
+
+PageView preload (인접 카드 build) → `_MappedThumb.initState` → loader 호출 → 사용자가 swipe 도달 시점에는 photo_manager 캐시에 byte 적재 완료. 검증: `FakeThumbnailLoader.callCount` 가 동일 (cellId, asset) 조합에 대해 위젯 lifecycle 동안 정확히 1회 (asset 변경 없는 경우).
+
+---
+
+## 5. `ThumbnailLoader` 어댑터
+
+### 5-1. 인터페이스
+
+```dart
+abstract class ThumbnailLoader {
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size});
+}
+```
+
+### 5-2. 프로덕션 구현
+
+```dart
+class PhotoManagerThumbnailLoader implements ThumbnailLoader {
+  const PhotoManagerThumbnailLoader();
+  @override
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size}) =>
+      asset.thumbnailDataWithSize(size);
+}
+
+@Riverpod(keepAlive: true)
+ThumbnailLoader thumbnailLoader(Ref ref) =>
+    const PhotoManagerThumbnailLoader();
+```
+
+### 5-3. 테스트 fake
+
+```dart
+class FakeThumbnailLoader implements ThumbnailLoader {
+  FakeThumbnailLoader({this.bytesById = const {}, this.failIds = const {}});
+  final Map<String, Uint8List> bytesById;  // asset.id → bytes
+  final Set<String> failIds;
+  int callCount = 0;
+
+  @override
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size}) async {
+    callCount += 1;
+    if (failIds.contains(asset.id)) return null;
+    return bytesById[asset.id];
+  }
+}
+```
+
+테스트는 `thumbnailLoaderProvider.overrideWith((_) => fake)` 로 주입.
+
+---
+
+## 6. 영상 ▶ 인디케이터
+
+| 항목 | 값 |
+|---|---|
+| 위치 | 셀 우상단 |
+| 인셋 | 8px (모든 방향) |
+| 아이콘 사이즈 | 16px (앱 16배수 그리드 준수) |
+| 아이콘 자산 | `assets/icons/icon_play.svg` (없으면 신규 추가) |
+| 아이콘 색 | `AppColors.offWhite` |
+| 배경 | `AppColors.charcoal40` 24px 원형 (Container shape: circle) |
+| 분기 | `asset.type == AssetType.video` 만 표시 |
+| 텍스트 | 없음 (duration 텍스트는 F07 sprint 에서 결정) |
+
+---
+
+## 7. PageView preload + fit (`suggestion_page.dart` 변경)
+
+기존:
+```dart
+PageView.builder(
+  controller: controller,
+  onPageChanged: onPageChanged,
+  itemCount: state.suggestions.length,
+  itemBuilder: ...,
+)
+```
+
+변경:
+```dart
+PageView.builder(
+  controller: controller,
+  allowImplicitScrolling: true,   // ← 신규: 인접 1장 preload
+  onPageChanged: onPageChanged,
+  itemCount: state.suggestions.length,
+  itemBuilder: ...,
+)
+```
+
+`allowImplicitScrolling: true` 는 PageView 의 `cacheExtent` 를 viewport 1장만큼 확장 → `_MappedThumb` 의 `FutureBuilder` 가 인접 카드에서도 미리 시작 → photo_manager 캐시에 byte 적재 → swipe 시 ⑤/⑥ 분기로 즉시 진입.
+
+---
+
+## 8. 에러 / fallback 매트릭스
+
+| 케이스 | 발생 빈도 | 시각 | 로그 |
+|---|---|---|---|
+| `mediaByCellId[cellId] == null` | 거의 0 (알고리즘 계약) | placeholder | `assert` (debug) + `debugPrint` |
+| `assetsById[id] == null` | 권한 limited 변경 / asset 삭제 | placeholder | `debugPrint` |
+| `thumbnailDataWithSize == null` | 코덱 / IO 실패 | placeholder | `debugPrint` |
+| 로딩 중 (`waiting`) | 정상 | placeholder (인디케이터 0) | 0 |
+
+PRD §F00 "편집 0" 컨셉상 어떤 실패도 사용자에게 위협 톤 노출 X. placeholder 톤은 picker 미선택 셀 / 카드 로딩 직후 톤과 동일.
+
+---
+
+## 9. 테스트 단위
+
+| Layer | 대상 | 검증 |
+|---|---|---|
+| **Unit** | `SelectedAssetsNotifier` | (a) `setAssets` 후 unmodifiable map (b) id key 정합성 (c) 빈 리스트 → 빈 map (d) 중복 id → 후입력 우선 |
+| **Widget** | `_MappedThumb` (Fake 주입) | (a) 정상 매핑 → `Image` 노드 1개, fit cover (b) `assetsById` 누락 → placeholder 톤 (c) loader 가 null → placeholder + debugPrint (d) 영상 자산 → ▶ icon finder 발견 (e) 위젯 lifecycle 중 임의 횟수 rebuild 후에도 동일 (cellId, asset) 에 대한 `FakeThumbnailLoader.callCount == 1` (f) `mediaByCellId` 가 다른 asset 으로 바뀌면 callCount 가 1 → 2 로 증가 |
+| **Widget** | `SuggestionCard` | mediaByCellId 매핑 셀 개수 = `_MappedThumb` 또는 fallback 렌더 개수 |
+| **Provider** | `photo_picker._onNext` 페어 호출 | `setMedia` 후 `selectedAssetsProvider` 도 채워졌는지 (`photo_picker_page_test.dart` 확장) |
+
+골든 테스트는 본 PR 범위 밖 — Phase D 후속 PR 에서 갱신.
+
+---
+
+## 10. 변경 영향 파일
+
+### 신규
+- `lib/features/suggestion/widgets/mapped_thumb.dart` (private 위젯) 또는 `suggestion_card.dart` 내 `_MappedThumb` 로 inline. (한 화면 한정 위젯이라 inline 권장)
+- `lib/features/suggestion/providers/selected_assets_provider.dart` + `.g.dart` (codegen)
+- `lib/features/suggestion/providers/thumbnail_loader.dart` + `.g.dart` (인터페이스 + photo_manager 구현 + Riverpod provider)
+- `assets/icons/icon_play.svg` (없을 경우)
+- `test/features/suggestion/widgets/mapped_thumb_test.dart`
+- `test/features/suggestion/providers/selected_assets_provider_test.dart`
+
+### 수정
+- `lib/features/suggestion/widgets/suggestion_card.dart` — `cellBuilder` 를 `_MappedThumb` 로 교체. `_PlaceholderCell` 은 fallback 용 private 유지. 인자에 `assetsById` 추가.
+- `lib/features/suggestion/suggestion_page.dart` — `PageView.builder(allowImplicitScrolling: true, ...)` + `selectedAssetsProvider` watch + `SuggestionCard` 에 `assetsById` prop 전달.
+- `lib/features/photo_picker/photo_picker_page.dart` — `_onNext` 에 `selectedAssetsProvider.setAssets(assets)` 페어 호출 추가.
+- `pubspec.yaml` — `assets/icons/icon_play.svg` 등록 (디렉터리 등록만 돼있으면 불필요).
+- `test/features/suggestion/suggestion_card_test.dart` — `_MappedThumb` 분기 검증으로 일부 기존 케이스 갱신 (placeholder 가정 → mapped 가정).
+- `test/features/photo_picker/photo_picker_page_test.dart` — `_onNext` 후 selectedAssetsProvider 채워졌는지 검증.
+
+### Spec
+- `docs/superpowers/specs/2026-04-27-suggestion-flow-design.md` §"GridTemplatePreview 승격" 표 v1.x 행 = 완료 ✓ + 본 spec 으로 cross-link. (구현 PR 시점에 함께 갱신)
+
+---
+
+## 11. 비범위 (Out of Scope)
+
+- ❌ Phase D 큐레이션 시각 iterate — 별 PR (이슈 본문 §검토 변수 §"Phase D 결정 프로세스" = "별도 후속 PR")
+- ❌ 셀 내 미디어 조작 / pinch-zoom / long-press — F06, Editor sprint
+- ❌ 영상 재생 / 자동 싱크 / 길이 조정 — F07, 별 sprint (PRD §9-2-4 "편집 0")
+- ❌ PNG 저장 — F08, Editor sprint (저장 화질은 Editor 셀 ImageProvider 해상도 ↔ `RepaintBoundary.pixelRatio` 매칭으로 결정 — 본 spec 의 썸네일 사이즈와 무관)
+- ❌ "다른 제안 보기" loadMore 시 신규 카드의 별도 preload 정책 — 동일 정책 자연 적용
+- ❌ photo_manager 자체 캐시 외 추가 LRU 캐시 — 필요 시 후속 spec
+- ❌ MediaItem ↔ AssetEntity 페어 깨지는 setMedia/setAssets 단독 호출 경로 추가 — 명시 금지
+
+---
+
+## 12. 후속 hooks
+
+| 후속 작업 | 본 spec 의 어떤 부분이 영향받나 |
+|---|---|
+| Phase D 큐레이션 시각 iterate | template entry 교체로 `mediaByCellId` 분포가 달라짐. `_MappedThumb` 자체는 무관. 영향 받는 골든은 후속 PR 에서 의도적 갱신 |
+| F06 셀 내 미디어 조작 (Editor) | `_MappedThumb` 시그니처에 `CellTransform?` 추가 가능성. Suggestion 화면은 transform 0 (기본 cover). Editor 의 셀 위젯은 `_MappedThumb` 와 별 위젯이 될 가능성 큼 (long-press / GestureDetector 책임) |
+| F07 영상 자동 싱크 | ▶ 인디케이터 옆에 duration 텍스트 추가 가능성 (PRD §9-2-4 의 T_min cap 노출). 본 spec §6 의 "텍스트 없음" 결정을 그때 재검토 |
+| F08 PNG 저장 | Editor 셀 ImageProvider 해상도 ↔ `RepaintBoundary.pixelRatio` 매칭이 별 spec 으로 결정. 본 spec 의 썸네일 사이즈(512) 와 무관 |

--- a/docs/superpowers/specs/2026-04-27-mapped-thumb-design.md
+++ b/docs/superpowers/specs/2026-04-27-mapped-thumb-design.md
@@ -29,7 +29,7 @@
 
 ### 2-1. 컴포넌트 트리
 
-```
+```text
 photo_picker route (기존)
 └─ _onNext()
    ├─ flowSelectionProvider.setMedia(items: List<MediaItem>)   (기존)
@@ -60,7 +60,7 @@ suggestion route
 
 ### 2-3. 의존성 흐름
 
-```
+```text
 features/suggestion ──depends──▶ cores/grid_suggestor (배럴, 기존)
 features/suggestion ──depends──▶ photo_manager (신규 / suggestion 영역 한정)
 features/photo_picker ──depends──▶ flow + suggestion.providers.selected_assets  (신규)
@@ -71,7 +71,7 @@ flow/, cores/grid_suggestor/ ──┃ photo_manager 의존성 0 유지 (기존 
 
 ## 3. 데이터 흐름
 
-```
+```text
 [picker] AssetSelectionNotifier (List<AssetEntity>, keepAlive: false)
               │ _onNext()
               ▼

--- a/docs/superpowers/specs/2026-04-27-suggestion-flow-design.md
+++ b/docs/superpowers/specs/2026-04-27-suggestion-flow-design.md
@@ -575,7 +575,7 @@ A 머지 → B → C → D 순서. A/B/C 사이 main rebase 가능.
 | 미래 작업 | 이 spec 의 받침대 |
 | --- | --- |
 | Editor 화면 (F02-F06) | `flowSelectionProvider.media` + `suggestion.suggestions[selectedIndex]` 가 그대로 Editor 초기 상태로 흐름 |
-| 사진 썸네일 매핑 (v1.x) | `BspGridLayout.cellBuilder` 를 `_PlaceholderCell` → `_MappedThumb(asset:...)` 로 swap. SuggestionCard 한 곳만 수정 |
+| 사진 썸네일 매핑 (v1.x) ✓ | 구현 완료 — `BspGridLayout.cellBuilder` 를 `_MappedThumb` 로 swap, `selectedAssetsProvider` 도입, PageView preload. 자세한 설계: [`2026-04-27-mapped-thumb-design.md`](./2026-04-27-mapped-thumb-design.md) |
 | F07 영상 자동 싱크 | `MediaItem.durationMs` 가 이미 변환에서 채워짐. `suggest(weightOf:...)` 인자만 채우면 알고리즘 재진입 |
 | F11 되돌리기/다시하기 | flow state 가 Riverpod Notifier — history stack push/pop 자연 |
 | F16 "내 템플릿" | dev gallery + suggestion 둘 다 `BspGridLayout` 사용 → 사용자 정의 NamedTemplate 시각화 즉시 |

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -13,6 +13,7 @@ import '../../cores/widgets/buttons/app_button.dart';
 import '../../cores/widgets/buttons/app_icon_button.dart';
 import '../../flow/flow_selection_provider.dart';
 import '../../routers/route_paths.dart';
+import '../suggestion/providers/selected_assets_provider.dart';
 
 /// 홈 화면 — Gridset 의 첫 화면.
 ///
@@ -54,11 +55,15 @@ class HomePage extends ConsumerWidget {
                 label: '사진·영상 고르기',
                 icon: Icons.image,
                 onPressed: () {
-                  // 흐름 시작 — 이전 흐름의 media 잔재를 명시적으로 비우고
-                  // 디폴트 9:16 으로 진입한다.
+                  // 흐름 시작 — 이전 흐름의 media + 선택 자산 잔재를 명시적으로
+                  // 비우고 디폴트 9:16 으로 진입한다. selectedAssets 는
+                  // keepAlive 라 reset 안 하면 다음 흐름까지 잔재 가능.
                   ref.read(flowSelectionNotifierProvider.notifier)
                     ..setMedia(const [])
                     ..setCanvas(const CanvasRatio.portrait916());
+                  ref
+                      .read(selectedAssetsNotifierProvider.notifier)
+                      .setAssets(const []);
                   context.push(RoutePaths.photoPicker);
                 },
               ),
@@ -67,10 +72,13 @@ class HomePage extends ConsumerWidget {
                 label: '비율 먼저 정하기',
                 onPressed: () {
                   // 흐름 시작 — canvas 는 picker 에서 다시 정하지만,
-                  // media 잔재만은 미리 정리한다.
+                  // media + 선택 자산 잔재만은 미리 정리한다 (둘 다 keepAlive).
                   ref
                       .read(flowSelectionNotifierProvider.notifier)
                       .setMedia(const []);
+                  ref
+                      .read(selectedAssetsNotifierProvider.notifier)
+                      .setAssets(const []);
                   context.push(RoutePaths.canvasPicker);
                 },
               ),

--- a/lib/features/photo_picker/photo_picker_page.dart
+++ b/lib/features/photo_picker/photo_picker_page.dart
@@ -9,6 +9,7 @@ import '../../cores/grid_suggestor/grid_suggestor.dart';
 import '../../cores/widgets/buttons/app_button.dart';
 import '../../flow/flow_selection_provider.dart';
 import '../../routers/route_paths.dart';
+import '../suggestion/providers/selected_assets_provider.dart';
 import 'asset_to_media_item.dart';
 import 'providers/asset_selection_provider.dart';
 import 'providers/permission_provider.dart';
@@ -77,7 +78,14 @@ class PhotoPickerPage extends ConsumerWidget {
         .whereType<MediaItem>()
         .toList(growable: false);
 
+    // 페어 호출 — flowSelection 은 알고리즘 입력 (MediaItem),
+    // selectedAssets 는 렌더링 자원 (AssetEntity). 둘 중 하나만 호출되면
+    // suggestion 화면이 silent 실패 (모든 셀 placeholder).
     ref.read(flowSelectionNotifierProvider.notifier).setMedia(items);
+    ref
+        .read(selectedAssetsNotifierProvider.notifier)
+        .setAssets(assets);
+
     context.push(RoutePaths.suggestion);
   }
 }

--- a/lib/features/photo_picker/photo_picker_page.dart
+++ b/lib/features/photo_picker/photo_picker_page.dart
@@ -81,6 +81,11 @@ class PhotoPickerPage extends ConsumerWidget {
     // 페어 호출 — flowSelection 은 알고리즘 입력 (MediaItem),
     // selectedAssets 는 렌더링 자원 (AssetEntity). 둘 중 하나만 호출되면
     // suggestion 화면이 silent 실패 (모든 셀 placeholder).
+    //
+    // 순서는 flowSelection → selectedAssets 로 고정한다. 둘 다 동기 setter
+    // 라 race 가 없지만, 향후 listener / async middleware 가 어느 한 쪽에
+    // 먼저 붙는 경우를 가정해 "알고리즘 입력이 먼저 정해진 뒤 자원이 따라
+    // 붙는다" 는 의미를 코드 순서로도 유지한다.
     ref.read(flowSelectionNotifierProvider.notifier).setMedia(items);
     ref
         .read(selectedAssetsNotifierProvider.notifier)

--- a/lib/features/suggestion/providers/selected_assets_provider.dart
+++ b/lib/features/suggestion/providers/selected_assets_provider.dart
@@ -16,9 +16,9 @@ class SelectedAssetsNotifier extends _$SelectedAssetsNotifier {
   @override
   Map<String, AssetEntity> build() => const {};
 
-  /// `id → AssetEntity` 로 정규화. List 의 순서는 알고리즘 입력
-  /// (`flow.media`) 에서만 의미 있고, 본 provider 는 lookup 용이라 Map.
-  /// `Map.unmodifiable` 로 외부 mutation 차단.
+  /// lookup 전용이므로 List 가 아닌 Map 으로 정규화.
+  /// (List 순서는 `flow.media` 알고리즘에서만 의미 있음.)
+  /// `Map.unmodifiable` 로 notifier 외부의 직접 수정을 차단한다.
   void setAssets(List<AssetEntity> items) =>
       state = Map.unmodifiable({for (final a in items) a.id: a});
 }

--- a/lib/features/suggestion/providers/selected_assets_provider.dart
+++ b/lib/features/suggestion/providers/selected_assets_provider.dart
@@ -1,0 +1,24 @@
+import 'package:photo_manager/photo_manager.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'selected_assets_provider.g.dart';
+
+/// picker → suggestion 흐름 동안 `Map<String, AssetEntity>` 보존.
+///
+/// `flowSelectionProvider` 와 페어로 picker `_onNext` 에서 채워짐.
+/// `_MappedThumb` 가 cellId → assetId → AssetEntity 를 해석할 때 lookup.
+///
+/// `keepAlive: true` — picker 라우트 떠난 직후 microtask 에서도 state 가
+/// 살아있어야 suggestion 화면이 처음 build 될 때 빈 map 으로 떨어지지 않음.
+/// (`flowSelectionProvider` 와 동일한 라이프사이클.)
+@Riverpod(keepAlive: true)
+class SelectedAssetsNotifier extends _$SelectedAssetsNotifier {
+  @override
+  Map<String, AssetEntity> build() => const {};
+
+  /// `id → AssetEntity` 로 정규화. List 의 순서는 알고리즘 입력
+  /// (`flow.media`) 에서만 의미 있고, 본 provider 는 lookup 용이라 Map.
+  /// `Map.unmodifiable` 로 외부 mutation 차단.
+  void setAssets(List<AssetEntity> items) =>
+      state = Map.unmodifiable({for (final a in items) a.id: a});
+}

--- a/lib/features/suggestion/providers/selected_assets_provider.g.dart
+++ b/lib/features/suggestion/providers/selected_assets_provider.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'selected_assets_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$selectedAssetsNotifierHash() =>
+    r'8bc6ebd5d6154f61f713504a30f91ac098fd4559';
+
+/// picker → suggestion 흐름 동안 `Map<String, AssetEntity>` 보존.
+///
+/// `flowSelectionProvider` 와 페어로 picker `_onNext` 에서 채워짐.
+/// `_MappedThumb` 가 cellId → assetId → AssetEntity 를 해석할 때 lookup.
+///
+/// `keepAlive: true` — picker 라우트 떠난 직후 microtask 에서도 state 가
+/// 살아있어야 suggestion 화면이 처음 build 될 때 빈 map 으로 떨어지지 않음.
+/// (`flowSelectionProvider` 와 동일한 라이프사이클.)
+///
+/// Copied from [SelectedAssetsNotifier].
+@ProviderFor(SelectedAssetsNotifier)
+final selectedAssetsNotifierProvider =
+    NotifierProvider<SelectedAssetsNotifier, Map<String, AssetEntity>>.internal(
+      SelectedAssetsNotifier.new,
+      name: r'selectedAssetsNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$selectedAssetsNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SelectedAssetsNotifier = Notifier<Map<String, AssetEntity>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/suggestion/providers/thumbnail_loader.dart
+++ b/lib/features/suggestion/providers/thumbnail_loader.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+import 'package:photo_manager/photo_manager.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+part 'thumbnail_loader.g.dart';
+
+/// photo_manager 의 `thumbnailDataWithSize` 호출을 1점에 격리하는 어댑터.
+///
+/// 테스트는 `thumbnailLoaderProvider.overrideWith((_) => FakeLoader(...))`
+/// 로 주입한다 — `_MappedThumb` 가 인터페이스에만 의존하므로 byte-level
+/// 모킹이 단순.
+abstract class ThumbnailLoader {
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size});
+}
+
+/// 프로덕션 구현 — photo_manager 직접 위임.
+class PhotoManagerThumbnailLoader implements ThumbnailLoader {
+  const PhotoManagerThumbnailLoader();
+
+  @override
+  Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size}) =>
+      asset.thumbnailDataWithSize(size);
+}
+
+/// `keepAlive: true` — 어댑터 자체는 stateless 라 dispose 부담 없음.
+/// 매번 새 인스턴스를 만들 이유도 없으므로 keepAlive.
+@Riverpod(keepAlive: true)
+ThumbnailLoader thumbnailLoader(Ref ref) =>
+    const PhotoManagerThumbnailLoader();

--- a/lib/features/suggestion/providers/thumbnail_loader.dart
+++ b/lib/features/suggestion/providers/thumbnail_loader.dart
@@ -1,8 +1,8 @@
 import 'dart:typed_data';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'thumbnail_loader.g.dart';
 
@@ -11,7 +11,10 @@ part 'thumbnail_loader.g.dart';
 /// 테스트는 `thumbnailLoaderProvider.overrideWith((_) => FakeLoader(...))`
 /// 로 주입한다 — `_MappedThumb` 가 인터페이스에만 의존하므로 byte-level
 /// 모킹이 단순.
-abstract class ThumbnailLoader {
+///
+/// `abstract interface class` — Dart 3 modifiers. 순수 계약이라 인스턴스화 /
+/// 상속 확장 모두 차단하고 `implements` 만 허용한다.
+abstract interface class ThumbnailLoader {
   Future<Uint8List?> load(AssetEntity asset, {required ThumbnailSize size});
 }
 

--- a/lib/features/suggestion/providers/thumbnail_loader.g.dart
+++ b/lib/features/suggestion/providers/thumbnail_loader.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'thumbnail_loader.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$thumbnailLoaderHash() => r'446027f974e2a9cc6013a112d3c823a999ca077b';
+
+/// `keepAlive: true` — 어댑터 자체는 stateless 라 dispose 부담 없음.
+/// 매번 새 인스턴스를 만들 이유도 없으므로 keepAlive.
+///
+/// Copied from [thumbnailLoader].
+@ProviderFor(thumbnailLoader)
+final thumbnailLoaderProvider = Provider<ThumbnailLoader>.internal(
+  thumbnailLoader,
+  name: r'thumbnailLoaderProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$thumbnailLoaderHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef ThumbnailLoaderRef = ProviderRef<ThumbnailLoader>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/suggestion/suggestion_page.dart
+++ b/lib/features/suggestion/suggestion_page.dart
@@ -92,10 +92,11 @@ class _SuggestionPageState extends ConsumerState<SuggestionPage> {
 
     final after = ref.read(suggestionNotifierProvider);
     if (after is SuggestionStateLoaded && after.cursor == null) {
+      // copy 아이콘은 복사 행위 전용. 마지막 제안 안내는 기본 siren 톤.
       AppSnackbar.show(
         context,
         message: '이게 마지막 제안이에요',
-        iconPath: 'assets/icons/icon_copy.svg',
+        iconPath: 'assets/icons/icon_siren.svg',
       );
     }
   }

--- a/lib/features/suggestion/suggestion_page.dart
+++ b/lib/features/suggestion/suggestion_page.dart
@@ -196,10 +196,16 @@ class _Loaded extends StatelessWidget {
                 child: AnimatedOpacity(
                   duration: const Duration(milliseconds: 200),
                   opacity: selected ? 1.0 : 0.5,
-                  child: SuggestionCard(
-                    suggestion: state.suggestions[i],
-                    canvas: state.canvas,
-                    assetsById: assetsById,
+                  // PageView 의 SliverFillViewport 는 자식을 양 axis tight 로
+                  // 강제하므로 안쪽 BspGridLayout 의 AspectRatio 가 무력화된다.
+                  // Center 로 감싸 자식이 비율대로 자기 사이즈 결정 + 가운데 정렬.
+                  // 결과: 9:16 → 세로 길게, 1:1 → 정사각형, 16:9 → 가로 길게.
+                  child: Center(
+                    child: SuggestionCard(
+                      suggestion: state.suggestions[i],
+                      canvas: state.canvas,
+                      assetsById: assetsById,
+                    ),
                   ),
                 ),
               );

--- a/lib/features/suggestion/suggestion_page.dart
+++ b/lib/features/suggestion/suggestion_page.dart
@@ -64,11 +64,7 @@ class _SuggestionPageState extends ConsumerState<SuggestionPage> {
               onPick: () => _stub(context, '에디터는 곧 준비됩니다'),
               onMore: state.cursor == null
                   ? null
-                  : () {
-                      ref
-                          .read(suggestionNotifierProvider.notifier)
-                          .loadMore();
-                    },
+                  : () => _onMore(context, ref),
               onBlank: () => _stub(context, '에디터는 곧 준비됩니다'),
             ),
         },
@@ -82,6 +78,26 @@ class _SuggestionPageState extends ConsumerState<SuggestionPage> {
       message: message,
       iconPath: 'assets/icons/icon_copy.svg',
     );
+  }
+
+  /// "다른 제안" 콜백 — loadMore 후 cursor 가 null 로 떨어지면 풀 소진을
+  /// 명시적으로 알려서 사용자가 "왜 다음부터 비활성?" 의문을 갖지 않게 한다.
+  ///
+  /// 풀 소진 케이스는 알고리즘이 다음 batch 후보가 없거나 PRD 한도(4 batch)에
+  /// 도달했을 때 발생. v1 의 작은 template 풀(N별 3~5개)에서는 1~2 batch 만에
+  /// 자주 발생 — 풀 보강은 후속 Phase D PR.
+  void _onMore(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(suggestionNotifierProvider.notifier);
+    notifier.loadMore();
+
+    final after = ref.read(suggestionNotifierProvider);
+    if (after is SuggestionStateLoaded && after.cursor == null) {
+      AppSnackbar.show(
+        context,
+        message: '이게 마지막 제안이에요',
+        iconPath: 'assets/icons/icon_copy.svg',
+      );
+    }
   }
 }
 

--- a/lib/features/suggestion/suggestion_page.dart
+++ b/lib/features/suggestion/suggestion_page.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 import '../../cores/constants/app_colors.dart';
 import '../../cores/constants/app_spacing.dart';
 import '../../cores/constants/app_text_style.dart';
 import '../../cores/widgets/snackbars/app_snackbar.dart';
+import 'providers/selected_assets_provider.dart';
 import 'providers/suggestion_notifier.dart';
 import 'providers/suggestion_state.dart';
 import 'widgets/suggestion_card.dart';
@@ -35,6 +37,7 @@ class _SuggestionPageState extends ConsumerState<SuggestionPage> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(suggestionNotifierProvider);
+    final assetsById = ref.watch(selectedAssetsNotifierProvider);
 
     return Scaffold(
       backgroundColor: AppColors.cream,
@@ -54,6 +57,7 @@ class _SuggestionPageState extends ConsumerState<SuggestionPage> {
           SuggestionStateError(:final message) => _Error(message: message),
           SuggestionStateLoaded() => _Loaded(
               state: state,
+              assetsById: assetsById,
               controller: _controller,
               onPageChanged: (i) =>
                   ref.read(suggestionNotifierProvider.notifier).selectIndex(i),
@@ -121,6 +125,7 @@ class _Error extends StatelessWidget {
 class _Loaded extends StatelessWidget {
   const _Loaded({
     required this.state,
+    required this.assetsById,
     required this.controller,
     required this.onPageChanged,
     required this.onPick,
@@ -129,6 +134,7 @@ class _Loaded extends StatelessWidget {
   });
 
   final SuggestionStateLoaded state;
+  final Map<String, AssetEntity> assetsById;
   final PageController controller;
   final ValueChanged<int> onPageChanged;
   final VoidCallback onPick;
@@ -159,6 +165,9 @@ class _Loaded extends StatelessWidget {
         Expanded(
           child: PageView.builder(
             controller: controller,
+            // 인접 1장 백그라운드 빌드 → _MappedThumb 의 FutureBuilder 가
+            // 미리 시작되어 swipe 시점에 photo_manager 캐시 적재 완료. 깜빡임 0.
+            allowImplicitScrolling: true,
             onPageChanged: onPageChanged,
             itemCount: state.suggestions.length,
             itemBuilder: (_, i) {
@@ -173,6 +182,7 @@ class _Loaded extends StatelessWidget {
                   child: SuggestionCard(
                     suggestion: state.suggestions[i],
                     canvas: state.canvas,
+                    assetsById: assetsById,
                   ),
                 ),
               );

--- a/lib/features/suggestion/widgets/suggestion_card.dart
+++ b/lib/features/suggestion/widgets/suggestion_card.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -160,8 +159,8 @@ class _VideoIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 24.w,
-      height: 24.w,
+      width: AppSpacing.xl,
+      height: AppSpacing.xl,
       decoration: const BoxDecoration(
         color: AppColors.charcoal40,
         shape: BoxShape.circle,
@@ -169,8 +168,8 @@ class _VideoIndicator extends StatelessWidget {
       alignment: Alignment.center,
       child: SvgPicture.asset(
         'assets/icons/icon_play.svg',
-        width: 16.w,
-        height: 16.w,
+        width: AppSpacing.base,
+        height: AppSpacing.base,
         colorFilter: const ColorFilter.mode(
           AppColors.offWhite,
           BlendMode.srcIn,

--- a/lib/features/suggestion/widgets/suggestion_card.dart
+++ b/lib/features/suggestion/widgets/suggestion_card.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -159,8 +160,8 @@ class _VideoIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 24,
-      height: 24,
+      width: 24.w,
+      height: 24.w,
       decoration: const BoxDecoration(
         color: AppColors.charcoal40,
         shape: BoxShape.circle,
@@ -168,8 +169,8 @@ class _VideoIndicator extends StatelessWidget {
       alignment: Alignment.center,
       child: SvgPicture.asset(
         'assets/icons/icon_play.svg',
-        width: 16,
-        height: 16,
+        width: 16.w,
+        height: 16.w,
         colorFilter: const ColorFilter.mode(
           AppColors.offWhite,
           BlendMode.srcIn,

--- a/lib/features/suggestion/widgets/suggestion_card.dart
+++ b/lib/features/suggestion/widgets/suggestion_card.dart
@@ -1,21 +1,31 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 import '../../../cores/constants/app_colors.dart';
+import '../../../cores/constants/app_spacing.dart';
 import '../../../cores/grid_suggestor/grid_suggestor.dart';
 import '../../../cores/widgets/grid_layout/bsp_grid_layout.dart';
+import '../providers/thumbnail_loader.dart';
 
-/// 후보 카드 한 개 — BspGridLayout 위에 placeholder 셀.
+/// 후보 카드 한 개 — BspGridLayout 위에 사진 썸네일 매핑.
 ///
-/// v1.x 에서 사진 썸네일 매핑 추가 예정 — cellBuilder 만 교체.
+/// `mediaByCellId` (cellId → assetId) 와 `assetsById` (assetId →
+/// AssetEntity) 두 lookup 을 거쳐 `_MappedThumb` 가 비동기 로드.
 class SuggestionCard extends StatelessWidget {
   const SuggestionCard({
     super.key,
     required this.suggestion,
     required this.canvas,
+    required this.assetsById,
   });
 
   final GridSuggestion suggestion;
   final CanvasRatio canvas;
+  final Map<String, AssetEntity> assetsById;
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +33,148 @@ class SuggestionCard extends StatelessWidget {
       tree: suggestion.tree,
       aspectRatio: canvas.value,
       borderColor: AppColors.lightCream,
-      cellBuilder: (_, _) => const _PlaceholderCell(),
+      cellBuilder: (cellId, _) => _MappedThumb(
+        cellId: cellId,
+        mediaByCellId: suggestion.mediaByCellId,
+        assetsById: assetsById,
+      ),
+    );
+  }
+}
+
+/// 매핑된 셀 — id → AssetEntity → 썸네일 byte → Image.memory(cover).
+///
+/// stateful — `FutureBuilder` 가 매 rebuild 마다 새 Future 를 받으면 한
+/// 프레임 `waiting` 으로 떨어져 깜빡임 발생. State 안에 future 를 1회만
+/// 시작하고 의존 입력 (cellId / asset) 변경 시에만 재생성한다.
+class _MappedThumb extends ConsumerStatefulWidget {
+  const _MappedThumb({
+    required this.cellId,
+    required this.mediaByCellId,
+    required this.assetsById,
+  });
+
+  final int cellId;
+  final Map<int, String> mediaByCellId;
+  final Map<String, AssetEntity> assetsById;
+
+  @override
+  ConsumerState<_MappedThumb> createState() => _MappedThumbState();
+}
+
+class _MappedThumbState extends ConsumerState<_MappedThumb> {
+  Future<Uint8List?>? _future;
+  AssetEntity? _asset;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveAndLoad();
+  }
+
+  @override
+  void didUpdateWidget(covariant _MappedThumb old) {
+    super.didUpdateWidget(old);
+    final prevId = old.mediaByCellId[old.cellId];
+    final nextId = widget.mediaByCellId[widget.cellId];
+    final prevAsset = prevId == null ? null : old.assetsById[prevId];
+    final nextAsset = nextId == null ? null : widget.assetsById[nextId];
+    // assetId 또는 asset.id 가 바뀐 경우에만 재로드.
+    // identical() 은 매 pumpWidget 마다 새 AssetEntity 인스턴스가 생성될 때
+    // 불필요한 재로드를 유발하므로 값(id) 비교로 대체한다.
+    if (prevId != nextId || prevAsset?.id != nextAsset?.id) {
+      _resolveAndLoad();
+    }
+  }
+
+  void _resolveAndLoad() {
+    final assetId = widget.mediaByCellId[widget.cellId];
+    assert(assetId != null,
+        'mediaByCellId 에 cellId=${widget.cellId} 매핑 없음 — 알고리즘 계약 위반');
+    final asset = assetId == null ? null : widget.assetsById[assetId];
+    _asset = asset;
+    if (asset == null) {
+      if (assetId != null) {
+        debugPrint('⚠️ asset 누락 cellId=${widget.cellId} id=$assetId');
+      }
+      _future = null;
+      return;
+    }
+    _future = ref
+        .read(thumbnailLoaderProvider)
+        .load(asset, size: const ThumbnailSize.square(512));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asset = _asset;
+    final future = _future;
+    if (asset == null || future == null) {
+      return const _PlaceholderCell();
+    }
+    return FutureBuilder<Uint8List?>(
+      future: future,
+      builder: (context, snap) {
+        if (snap.connectionState == ConnectionState.waiting) {
+          return const _PlaceholderCell();
+        }
+        final bytes = snap.data;
+        if (snap.hasError || bytes == null) {
+          debugPrint(
+            '⚠️ thumb load 실패 cellId=${widget.cellId} '
+            'asset=${asset.id} err=${snap.error}',
+          );
+          return const _PlaceholderCell();
+        }
+        final image = Image.memory(
+          bytes,
+          fit: BoxFit.cover,
+          gaplessPlayback: true,
+        );
+        if (asset.type == AssetType.video) {
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              image,
+              Positioned(
+                top: AppSpacing.sm,
+                right: AppSpacing.sm,
+                child: const _VideoIndicator(),
+              ),
+            ],
+          );
+        }
+        return image;
+      },
+    );
+  }
+}
+
+/// 영상 셀 우상단에 표시되는 ▶ 아이콘 오버레이.
+///
+/// charcoal40(반투명) 원형 배경 — 썸네일 색상에 관계없이 아이콘 가시성 확보.
+class _VideoIndicator extends StatelessWidget {
+  const _VideoIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 24,
+      height: 24,
+      decoration: const BoxDecoration(
+        color: AppColors.charcoal40,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: SvgPicture.asset(
+        'assets/icons/icon_play.svg',
+        width: 16,
+        height: 16,
+        colorFilter: const ColorFilter.mode(
+          AppColors.offWhite,
+          BlendMode.srcIn,
+        ),
+      ),
     );
   }
 }
@@ -33,9 +184,7 @@ class _PlaceholderCell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // spec(2026-04-27-suggestion-flow-design.md) §"GridTemplatePreview 승격" 표 기준:
-    // lightCream(#ECEAE4) 채움 + charcoal04 분할선. cream(#F7F4ED) 카드 위에서
-    // 셀 모자이크가 한 톤 어두운 warm-gray 로 또렷이 분할되어 보인다.
+    // 매핑 실패 / 로딩 중 모두 동일 톤. 사용자에게 위협 톤 노출 X.
     return Container(
       decoration: BoxDecoration(
         color: AppColors.lightCream,

--- a/lib/flow/flow_selection_provider.g.dart
+++ b/lib/flow/flow_selection_provider.g.dart
@@ -7,7 +7,7 @@ part of 'flow_selection_provider.dart';
 // **************************************************************************
 
 String _$flowSelectionNotifierHash() =>
-    r'eb78305a037541a2727576e1fe88d80057a727bd';
+    r'c638ca12dfbcdba9c9ae528207fd38ceb80e76fd';
 
 /// 흐름 공유 상태 Notifier.
 ///

--- a/test/features/canvas_picker/canvas_picker_page_test.dart
+++ b/test/features/canvas_picker/canvas_picker_page_test.dart
@@ -89,4 +89,62 @@ void main() {
       const CanvasRatio.portrait916(), // 디폴트
     );
   });
+
+  // 회귀 — chip 선택값이 setCanvas 까지 정확히 흘러야 한다. 시뮬레이터에서
+  // "어떤 비율을 골라도 같은 모양" 으로 보이는 인상이 보고된 적 있어 가드.
+  for (final entry in const {
+    '1:1': CanvasRatio.square(),
+    '4:5': CanvasRatio.portrait45(),
+    '16:9': CanvasRatio.landscape169(),
+    '9:16': CanvasRatio.portrait916(),
+  }.entries) {
+    testWidgets(
+      '${entry.key} chip 선택 → 다음 → flow.canvas == ${entry.value.value}',
+      (tester) async {
+        _useDesignViewport(tester);
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        final router = GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const CanvasPickerPage(),
+            ),
+            GoRoute(
+              path: '/photo-picker',
+              builder: (context, state) =>
+                  const Scaffold(body: Text('photo-stub')),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: ScreenUtilInit(
+              designSize: _kDesignSize,
+              minTextAdapt: true,
+              builder: (context, _) =>
+                  MaterialApp.router(routerConfig: router),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(entry.key));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('다음'));
+        await tester.pumpAndSettle();
+
+        expect(
+          container.read(flowSelectionNotifierProvider).canvas,
+          entry.value,
+          reason:
+              '${entry.key} chip 을 선택하고 "다음" 누르면 flow.canvas 가 그 값이어야 함',
+        );
+      },
+    );
+  }
 }

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -5,8 +5,12 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
 import 'package:gridset/cores/widgets/buttons/app_icon_button.dart';
 import 'package:gridset/features/home/home_page.dart';
+import 'package:gridset/features/suggestion/providers/selected_assets_provider.dart';
+import 'package:gridset/flow/flow_selection_provider.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 const _kDesignSize = Size(393, 852);
 
@@ -79,6 +83,98 @@ void main() {
       // trailing 슬롯의 AppIconButton — 우상단
       expect(find.byType(AppIconButton), findsOneWidget);
       expect(find.byIcon(Icons.gps_fixed), findsOneWidget);
+    });
+
+    // 회귀 — flow.media + selectedAssets 가 keepAlive 라 home CTA 진입 시
+    // 둘 다 명시적 reset 필요. 한 쪽만 비우면 다음 흐름에서 잔재 lookup 발생.
+    testWidgets('CTA "사진·영상 고르기" 진입 시 flow.media + selectedAssets 둘 다 reset',
+        (tester) async {
+      _useDesignViewport(tester);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // 이전 흐름 상태 가짜로 채워놓기.
+      container
+          .read(flowSelectionNotifierProvider.notifier)
+          .setMedia(const [
+        MediaItem(id: 'old', type: MediaType.photo, aspectRatio: 1.0),
+      ]);
+      container
+          .read(selectedAssetsNotifierProvider.notifier)
+          .setAssets([
+        AssetEntity(id: 'old', typeInt: 1, width: 100, height: 100),
+      ]);
+
+      final router = GoRouter(initialLocation: '/', routes: [
+        GoRoute(path: '/', builder: (_, _) => const HomePage()),
+        GoRoute(
+            path: '/photo-picker',
+            builder: (_, _) => const Scaffold(body: Text('photo-picker-stub'))),
+        GoRoute(
+            path: '/canvas-picker',
+            builder: (_, _) =>
+                const Scaffold(body: Text('canvas-picker-stub'))),
+      ]);
+      await tester.pumpWidget(UncontrolledProviderScope(
+        container: container,
+        child: ScreenUtilInit(
+          designSize: _kDesignSize,
+          minTextAdapt: true,
+          builder: (context, _) => MaterialApp.router(routerConfig: router),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('사진·영상 고르기'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(flowSelectionNotifierProvider).media, isEmpty);
+      expect(container.read(selectedAssetsNotifierProvider), isEmpty,
+          reason: 'keepAlive 라 명시 reset 안 하면 잔재 lookup');
+    });
+
+    testWidgets('CTA "비율 먼저 정하기" 진입 시 flow.media + selectedAssets 둘 다 reset',
+        (tester) async {
+      _useDesignViewport(tester);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container
+          .read(flowSelectionNotifierProvider.notifier)
+          .setMedia(const [
+        MediaItem(id: 'old', type: MediaType.photo, aspectRatio: 1.0),
+      ]);
+      container
+          .read(selectedAssetsNotifierProvider.notifier)
+          .setAssets([
+        AssetEntity(id: 'old', typeInt: 1, width: 100, height: 100),
+      ]);
+
+      final router = GoRouter(initialLocation: '/', routes: [
+        GoRoute(path: '/', builder: (_, _) => const HomePage()),
+        GoRoute(
+            path: '/photo-picker',
+            builder: (_, _) => const Scaffold(body: Text('photo-picker-stub'))),
+        GoRoute(
+            path: '/canvas-picker',
+            builder: (_, _) =>
+                const Scaffold(body: Text('canvas-picker-stub'))),
+      ]);
+      await tester.pumpWidget(UncontrolledProviderScope(
+        container: container,
+        child: ScreenUtilInit(
+          designSize: _kDesignSize,
+          minTextAdapt: true,
+          builder: (context, _) => MaterialApp.router(routerConfig: router),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('비율 먼저 정하기'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(flowSelectionNotifierProvider).media, isEmpty);
+      expect(container.read(selectedAssetsNotifierProvider), isEmpty);
     });
   });
 }

--- a/test/features/photo_picker/photo_picker_page_test.dart
+++ b/test/features/photo_picker/photo_picker_page_test.dart
@@ -3,9 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
 import 'package:gridset/cores/widgets/buttons/app_button.dart';
+import 'package:gridset/features/photo_picker/asset_to_media_item.dart';
 import 'package:gridset/features/photo_picker/photo_picker_page.dart';
 import 'package:gridset/features/photo_picker/providers/permission_provider.dart';
+import 'package:gridset/features/suggestion/providers/selected_assets_provider.dart';
+import 'package:gridset/flow/flow_selection_provider.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 Widget _harness(Widget child, {required AppPermissionState perm}) {
   return ProviderScope(
@@ -77,5 +82,42 @@ void main() {
     );
     expect(nextBtn.onPressed, isNull,
         reason: '2장 미만 선택 시 다음 버튼 비활성');
+  });
+
+  // _onNext 자체는 위젯 내부 private 메서드라 직접 호출 불가.
+  // 두 setter 가 묶여 있어야 함을 contract-level 로 가드한다.
+  // (회귀 시 Task 5 의 mapped_thumb_test 가 실패해 영향 검증.)
+  test('flow.media + selectedAssets — 같은 source 로 함께 채워짐 (페어 contract)',
+      () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final assets = [
+      AssetEntity(id: 'p1', typeInt: 1, width: 100, height: 100),
+      AssetEntity(id: 'p2', typeInt: 1, width: 100, height: 100),
+    ];
+
+    final items = assets
+        .map(assetToMediaItem)
+        .whereType<MediaItem>()
+        .toList(growable: false);
+
+    container.read(flowSelectionNotifierProvider.notifier).setMedia(items);
+    container
+        .read(selectedAssetsNotifierProvider.notifier)
+        .setAssets(assets);
+
+    expect(
+      container
+          .read(flowSelectionNotifierProvider)
+          .media
+          .map((m) => m.id)
+          .toList(),
+      ['p1', 'p2'],
+    );
+    expect(
+      container.read(selectedAssetsNotifierProvider).keys.toList(),
+      ['p1', 'p2'],
+    );
   });
 }

--- a/test/features/suggestion/providers/selected_assets_provider_test.dart
+++ b/test/features/suggestion/providers/selected_assets_provider_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gridset/features/suggestion/providers/selected_assets_provider.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+// 테스트용 가짜 AssetEntity — id 만 사용. photo_manager 의 AssetEntity 는
+// final 클래스라 `AssetEntity(id: ..., typeInt: 1, width: 1, height: 1)` 로
+// 직접 생성해도 native 호출이 일어나지 않으므로 unit test 안전.
+AssetEntity _fake(String id) => AssetEntity(
+      id: id,
+      typeInt: 1, // image
+      width: 100,
+      height: 100,
+    );
+
+void main() {
+  test('초기 state 는 빈 map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(selectedAssetsNotifierProvider), isEmpty);
+  });
+
+  test('setAssets — list → id 키 map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets([_fake('a'), _fake('b')]);
+
+    final state = container.read(selectedAssetsNotifierProvider);
+    expect(state.keys, ['a', 'b']);
+    expect(state['a']!.id, 'a');
+    expect(state['b']!.id, 'b');
+  });
+
+  test('setAssets — 빈 리스트 → 빈 map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets(const []);
+    expect(container.read(selectedAssetsNotifierProvider), isEmpty);
+  });
+
+  test('setAssets — 동일 id 중복 → 후입력 우선 (last-wins)', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    final first = _fake('x');
+    final second = _fake('x'); // 같은 id 의 다른 인스턴스
+    notifier.setAssets([first, second]);
+
+    final state = container.read(selectedAssetsNotifierProvider);
+    expect(state.length, 1);
+    expect(identical(state['x'], second), isTrue,
+        reason: 'Map literal 의 last-wins 시맨틱과 일관');
+  });
+
+  test('state map 은 수정 불가', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets([_fake('a')]);
+    final state = container.read(selectedAssetsNotifierProvider);
+
+    expect(() => state['b'] = _fake('b'), throwsUnsupportedError);
+  });
+}

--- a/test/features/suggestion/providers/selected_assets_provider_test.dart
+++ b/test/features/suggestion/providers/selected_assets_provider_test.dart
@@ -71,4 +71,23 @@ void main() {
 
     expect(() => state['b'] = _fake('b'), throwsUnsupportedError);
   });
+
+  // keepAlive 이라 화면 전환 후에도 state 가 살아있다.
+  // 이전 picker 선택 잔재가 남으면 다음 흐름에서 mediaByCellId 와 어긋나
+  // 매핑 실패 fallback 으로 떨어진다 — 재호출 시 전체 교체를 보증.
+  test('setAssets 재호출 시 이전 state 전체 교체', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier =
+        container.read(selectedAssetsNotifierProvider.notifier);
+
+    notifier.setAssets([_fake('a'), _fake('b')]);
+    notifier.setAssets([_fake('c')]);
+
+    final state = container.read(selectedAssetsNotifierProvider);
+    expect(state.keys, ['c']);
+    expect(state.containsKey('a'), isFalse,
+        reason: '이전 state 의 항목이 남으면 다음 picker 흐름이 오염됨');
+    expect(state.containsKey('b'), isFalse);
+  });
 }

--- a/test/features/suggestion/suggestion_card_test.dart
+++ b/test/features/suggestion/suggestion_card_test.dart
@@ -1,6 +1,6 @@
-// material 의 Split (animation curve) 와 grid_suggestor 의 Split (BSP node) 이 동명.
-// bsp_grid_layout.dart 와 동일하게 material 의 Split 을 hide 한다.
 import 'package:flutter/material.dart' hide Split;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gridset/cores/constants/app_colors.dart';
 import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
@@ -10,10 +10,12 @@ void main() {
   // 회귀 방지 — spec(2026-04-27-suggestion-flow-design.md) 의
   // "Suggestion v1: lightCream 배경 + charcoal04 border" 와 코드가 swap 되어
   // 셀 분할이 cream 배경 위에서 시각적으로 사라졌던 사례.
+  //
+  // v1.x mapped-thumb-design 도입 후: assetsById 가 비어있는 fallback 경로에서도
+  // 동일한 placeholder 톤이 유지됨을 보증.
   testWidgets(
-    'SuggestionCard 의 placeholder 셀은 lightCream 배경 + charcoal04 분할선',
+    'SuggestionCard — assetsById 누락 시 placeholder 톤 유지 (lightCream + charcoal04)',
     (tester) async {
-      // 두 셀을 가진 최소 트리 — V-split 좌/우.
       final suggestion = GridSuggestion(
         tree: Split(
           axis: SplitAxis.vertical,
@@ -26,37 +28,42 @@ void main() {
       );
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: SuggestionCard(
-                suggestion: suggestion,
-                canvas: const CanvasRatio.square(),
+        ProviderScope(
+          child: ScreenUtilInit(
+            designSize: const Size(393, 852),
+            child: MaterialApp(
+              home: Scaffold(
+                body: Center(
+                  child: SuggestionCard(
+                    suggestion: suggestion,
+                    canvas: const CanvasRatio.square(),
+                    assetsById: const {}, // 매핑 누락 — fallback 경로
+                  ),
+                ),
               ),
             ),
           ),
         ),
       );
+      await tester.pumpAndSettle();
 
-      // SuggestionCard 안의 Container 는 _PlaceholderCell 의 것뿐 (BspGridLayout 은
-      // DecoratedBox/ClipRRect 만 쓴다). 두 leaf → 두 Container.
-      final containers = tester.widgetList<Container>(
-        find.descendant(
-          of: find.byType(SuggestionCard),
-          matching: find.byType(Container),
-        ),
-      );
-
-      expect(containers, hasLength(2),
+      // _PlaceholderCell 의 Container 만 lightCream 배경을 가짐.
+      final placeholders = tester
+          .widgetList<Container>(
+            find.descendant(
+              of: find.byType(SuggestionCard),
+              matching: find.byType(Container),
+            ),
+          )
+          .where((c) {
+        final dec = c.decoration;
+        return dec is BoxDecoration && dec.color == AppColors.lightCream;
+      });
+      expect(placeholders, hasLength(2),
           reason: 'leaf 마다 placeholder 한 개');
 
-      for (final c in containers) {
+      for (final c in placeholders) {
         final decoration = c.decoration as BoxDecoration;
-        expect(
-          decoration.color,
-          AppColors.lightCream,
-          reason: 'spec: lightCream 배경 (cream 위에서 한 톤 어둡게 보여야 함)',
-        );
         final border = decoration.border as Border;
         expect(
           border.top.color,

--- a/test/features/suggestion/suggestion_page_test.dart
+++ b/test/features/suggestion/suggestion_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
 import 'package:gridset/features/suggestion/suggestion_page.dart';
+import 'package:gridset/features/suggestion/widgets/suggestion_card.dart';
 import 'package:gridset/flow/flow_selection_provider.dart';
 
 void main() {
@@ -167,6 +168,22 @@ void main() {
           expect(ar.aspectRatio, ratio.value,
               reason: 'flow.canvas=${ratio.value} 가 카드까지 그대로 흘러야 함');
         }
+
+        // 실 렌더 사이즈 검증 — Widget property 가 set 되어도 부모가 양 axis
+        // tight 로 강제하면 AspectRatio 가 무력화돼 카드 외곽이 모두 viewport
+        // 사이즈로 stretch 되는 회귀 버그 (Center wrapping 으로 fix). 카드의
+        // actual width/height 비율이 사용자 선택값과 일치하는지 검증.
+        final renderRect = tester.getRect(find
+            .descendant(
+              of: find.byType(SuggestionCard).first,
+              matching: find.byType(AspectRatio),
+            )
+            .first);
+        final renderRatio = renderRect.width / renderRect.height;
+        expect(renderRatio, closeTo(ratio.value, 0.01),
+            reason: '카드 실 렌더 사이즈 비율이 사용자 선택값과 일치해야 함 — '
+                'PageView SliverFillViewport 가 자식을 강제 fit 하지 못하도록 '
+                'Center 로 감싸야 한다');
       },
     );
   }

--- a/test/features/suggestion/suggestion_page_test.dart
+++ b/test/features/suggestion/suggestion_page_test.dart
@@ -119,4 +119,55 @@ void main() {
       expect(find.text('이게 마지막 제안이에요'), findsOneWidget);
     },
   );
+
+  // 진단 — canvas-picker 에서 1:1 / 4:5 / 16:9 / 9:16 어떤 비율을 골라도
+  // SuggestionCard 의 BspGridLayout 이 사용자 선택대로 aspectRatio 를 적용해야.
+  // 회귀 시 모든 비율이 같은 모양으로 보이는 버그를 즉시 잡는다.
+  for (final ratio in const [
+    CanvasRatio.portrait916(),
+    CanvasRatio.square(),
+    CanvasRatio.portrait45(),
+    CanvasRatio.landscape169(),
+  ]) {
+    testWidgets(
+      'flow.canvas=${ratio.value} → BspGridLayout.aspectRatio 그대로 흐름',
+      (tester) async {
+        const media = [
+          MediaItem(id: 'a', type: MediaType.photo, aspectRatio: 1.0),
+          MediaItem(id: 'b', type: MediaType.photo, aspectRatio: 1.5),
+        ];
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container
+            .read(flowSelectionNotifierProvider.notifier)
+            .setMedia(media);
+        container
+            .read(flowSelectionNotifierProvider.notifier)
+            .setCanvas(ratio);
+
+        await tester.pumpWidget(UncontrolledProviderScope(
+          container: container,
+          child: ScreenUtilInit(
+            designSize: const Size(393, 852),
+            child: const MaterialApp(home: SuggestionPage()),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        final layouts = tester.widgetList<AspectRatio>(
+          find.descendant(
+            of: find.byType(SuggestionPage),
+            matching: find.byType(AspectRatio),
+          ),
+        );
+        // 카드마다 1개의 AspectRatio (BspGridLayout 안). 모두 사용자 선택값.
+        expect(layouts, isNotEmpty);
+        for (final ar in layouts) {
+          expect(ar.aspectRatio, ratio.value,
+              reason: 'flow.canvas=${ratio.value} 가 카드까지 그대로 흘러야 함');
+        }
+      },
+    );
+  }
 }

--- a/test/features/suggestion/suggestion_page_test.dart
+++ b/test/features/suggestion/suggestion_page_test.dart
@@ -85,4 +85,38 @@ void main() {
       expect(pageViewRect.right, screenSize.width, reason: '우측 풀브리드');
     },
   );
+
+  // 사용자가 "다른 제안" 버튼을 한 번 누른 뒤 비활성화 되는 케이스의 안내.
+  // 현재 알고리즘 풀이 작아 N 별로 1~2 batch 만에 cursor 가 null 로 떨어짐 —
+  // 사용자에게 "왜 더 이상 안 눌리지?" 의문을 남기지 않도록 SnackBar 로 명시.
+  testWidgets(
+    'loadMore 후 cursor null 전이 시 "이게 마지막 제안이에요" SnackBar',
+    (tester) async {
+      // N=3 (template 4개) — 첫 batch 3 + 두 번째 batch 1 → cursor null.
+      const media = [
+        MediaItem(id: 'a', type: MediaType.photo, aspectRatio: 1.0),
+        MediaItem(id: 'b', type: MediaType.photo, aspectRatio: 1.5),
+        MediaItem(id: 'c', type: MediaType.photo, aspectRatio: 0.7),
+      ];
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(flowSelectionNotifierProvider.notifier).setMedia(media);
+
+      await tester.pumpWidget(UncontrolledProviderScope(
+        container: container,
+        child: ScreenUtilInit(
+          designSize: const Size(393, 852),
+          child: const MaterialApp(home: SuggestionPage()),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // "다른 제안" 한 번 tap → loadMore → cursor null → SnackBar.
+      await tester.tap(find.text('다른 제안'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('이게 마지막 제안이에요'), findsOneWidget);
+    },
+  );
 }

--- a/test/features/suggestion/widgets/mapped_thumb_test.dart
+++ b/test/features/suggestion/widgets/mapped_thumb_test.dart
@@ -1,0 +1,227 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' hide Split;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gridset/cores/constants/app_colors.dart';
+import 'package:gridset/cores/grid_suggestor/grid_suggestor.dart';
+import 'package:gridset/features/suggestion/providers/thumbnail_loader.dart';
+import 'package:gridset/features/suggestion/widgets/suggestion_card.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+class _FakeLoader implements ThumbnailLoader {
+  _FakeLoader({this.bytesById = const {}, this.failIds = const {}});
+  final Map<String, Uint8List> bytesById;
+  final Set<String> failIds;
+  int callCount = 0;
+
+  @override
+  Future<Uint8List?> load(AssetEntity asset,
+      {required ThumbnailSize size}) async {
+    callCount += 1;
+    if (failIds.contains(asset.id)) return null;
+    return bytesById[asset.id];
+  }
+}
+
+// 1×1 transparent PNG — 위젯이 Image.memory 로 렌더할 수 있는 가장 작은 byte.
+final Uint8List _kTinyPng = Uint8List.fromList([
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+  0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+  0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+]);
+
+AssetEntity _photo(String id) =>
+    AssetEntity(id: id, typeInt: 1, width: 100, height: 100);
+AssetEntity _video(String id) =>
+    AssetEntity(id: id, typeInt: 2, width: 100, height: 100);
+
+Widget _harness({
+  required Widget child,
+  required _FakeLoader loader,
+}) {
+  return ProviderScope(
+    overrides: [thumbnailLoaderProvider.overrideWith((_) => loader)],
+    child: ScreenUtilInit(
+      designSize: const Size(393, 852),
+      child: MaterialApp(home: Scaffold(body: child)),
+    ),
+  );
+}
+
+GridSuggestion _twoCellSuggestion({
+  String idA = 'a',
+  String idB = 'b',
+}) =>
+    GridSuggestion(
+      tree: Split(
+        axis: SplitAxis.vertical,
+        positions: const [0.5],
+        children: const [Leaf(0), Leaf(1)],
+      ),
+      mediaByCellId: {0: idA, 1: idB},
+      loss: 0.0,
+      templateName: 'test_2',
+    );
+
+void main() {
+  testWidgets('(a) 정상 매핑 → Image 노드, fit cover', (tester) async {
+    final loader = _FakeLoader(bytesById: {'a': _kTinyPng, 'b': _kTinyPng});
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final images = tester.widgetList<Image>(find.byType(Image));
+    expect(images, hasLength(2), reason: '두 leaf → 두 Image');
+    for (final img in images) {
+      expect(img.fit, BoxFit.cover);
+      expect(img.gaplessPlayback, isTrue);
+    }
+  });
+
+  testWidgets('(b) assetsById 누락 → placeholder 톤', (tester) async {
+    final loader = _FakeLoader();
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: const {},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsNothing);
+    final placeholders = tester
+        .widgetList<Container>(
+          find.descendant(
+            of: find.byType(SuggestionCard),
+            matching: find.byType(Container),
+          ),
+        )
+        .where((c) {
+      final dec = c.decoration;
+      return dec is BoxDecoration && dec.color == AppColors.lightCream;
+    });
+    expect(placeholders, hasLength(2));
+    expect(loader.callCount, 0, reason: 'asset 없으면 loader 호출 X');
+  });
+
+  testWidgets('(c) loader 가 null → placeholder', (tester) async {
+    final loader = _FakeLoader(failIds: {'a', 'b'});
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsNothing);
+    expect(loader.callCount, 2);
+  });
+
+  testWidgets('(d) 영상 자산 → ▶ icon overlay', (tester) async {
+    final loader = _FakeLoader(bytesById: {'v': _kTinyPng});
+    final suggestion = GridSuggestion(
+      tree: const Leaf(0),
+      mediaByCellId: const {0: 'v'},
+      loss: 0.0,
+      templateName: 'test_1',
+    );
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: suggestion,
+        canvas: const CanvasRatio.square(),
+        assetsById: {'v': _video('v')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsOneWidget);
+    // SvgPicture.asset 으로 그려진 ▶ icon — asset path 가 'icon_play' 포함되는지로 식별.
+    expect(
+      find.byWidgetPredicate((w) =>
+          w is SvgPicture && w.bytesLoader.toString().contains('icon_play')),
+      findsOneWidget,
+      reason: '영상 셀은 ▶ overlay 가 깔림',
+    );
+  });
+
+  testWidgets(
+      '(e) rebuild 후에도 동일 (cellId, asset) 에 대한 callCount == 1',
+      (tester) async {
+    final loader = _FakeLoader(bytesById: {'a': _kTinyPng, 'b': _kTinyPng});
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+    final initial = loader.callCount;
+    expect(initial, 2, reason: '셀 2개 × 1회');
+
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(loader.callCount, initial,
+        reason: '동일 (cellId, asset) → didUpdateWidget 비교 후 재호출 X');
+  });
+
+  testWidgets('(f) asset 변경 시 callCount 증가', (tester) async {
+    final loader = _FakeLoader(
+      bytesById: {'a': _kTinyPng, 'b': _kTinyPng, 'a2': _kTinyPng},
+    );
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(idA: 'a'),
+        canvas: const CanvasRatio.square(),
+        assetsById: {'a': _photo('a'), 'b': _photo('b')},
+      ),
+    ));
+    await tester.pumpAndSettle();
+    final before = loader.callCount;
+
+    await tester.pumpWidget(_harness(
+      loader: loader,
+      child: SuggestionCard(
+        suggestion: _twoCellSuggestion(idA: 'a2'),
+        canvas: const CanvasRatio.square(),
+        assetsById: {
+          'a': _photo('a'),
+          'a2': _photo('a2'),
+          'b': _photo('b'),
+        },
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(loader.callCount, greaterThan(before),
+        reason: 'cell 0 의 asset 이 바뀌었으므로 재로드 1회 발생');
+  });
+}

--- a/test/features/suggestion/widgets/mapped_thumb_test.dart
+++ b/test/features/suggestion/widgets/mapped_thumb_test.dart
@@ -153,10 +153,15 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(Image), findsOneWidget);
-    // SvgPicture.asset 으로 그려진 ▶ icon — asset path 가 'icon_play' 포함되는지로 식별.
+    // SvgAssetLoader.assetName 으로 식별 — toString 포맷이 flutter_svg 버전 업
+    // 시 바뀌어도 견고. (이전 toString().contains 방식은 silent fail 위험.)
     expect(
-      find.byWidgetPredicate((w) =>
-          w is SvgPicture && w.bytesLoader.toString().contains('icon_play')),
+      find.byWidgetPredicate((w) {
+        if (w is! SvgPicture) return false;
+        final loader = w.bytesLoader;
+        return loader is SvgAssetLoader &&
+            loader.assetName.contains('icon_play');
+      }),
       findsOneWidget,
       reason: '영상 셀은 ▶ overlay 가 깔림',
     );


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제안 그리드에 선택한 사진/동영상의 실제 썸네일을 매핑해 표시
  * 동영상에 재생 아이콘 오버레이 표시
  * 픽커→제안 전환 시 선택된 자산 상태를 유지

* **개선 사항**
  * 인접 페이지 미리 로드를 통해 제안 탐색 성능 향상
  * "다른 제안" 후 마지막 제안 도달 시 안내 스낵바 표시
  * 플로우 시작 시 선택 자산 초기화 동작 일관화

* **테스트/문서**
  * 매핑 썸네일 동작 및 관련 경계 사례에 대한 테스트와 설계 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->